### PR TITLE
Add ability to build for Arm64 Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ For some platforms there are scripts inside the package.json.
 
 `npm run build:x64:linux`
 
+`npm run build:arm64:linux`
+
 ## Usage
 
 After configuration the app will automaticly start the liveview after startup. If you want to change the configuration or when you misspell your credentials you can press `F10` to reset all settings and restart the configuration process.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build:arm64:macos:portable": "electron-packager ./ unifi-protect-viewer-portable --overwrite --platform darwin --arch arm64 --icon ./src/img/128.png --prune=true --out=builds",
     "build:x64:linux": "electron-packager ./ unifi-protect-viewer --overwrite --asar --platform linux --arch x64 --icon ./src/img/128.png --prune true --out builds",
     "build:x64:linux:portable": "electron-packager ./ unifi-protect-viewer-portable --overwrite --asar --platform linux --arch x64 --icon ./src/img/128.png --prune true --out builds",
+    "build:arm64:linux": "electron-packager ./ unifi-protect-viewer --overwrite --asar --platform linux --arch arm64 --icon ./src/img/128.png --prune true --out builds",
+    "build:arm64:linux:portable": "electron-packager ./ unifi-protect-viewer-portable --overwrite --asar --platform linux --arch arm64 --icon ./src/img/128.png --prune true --out builds",
     "rename": "node scripts/rename-builds.js"
   },
   "keywords": [


### PR DESCRIPTION
Tested this last night locally to run this software on a Rapsberry Pi and application worked exactly as expected.

I did run into performance issues of the streams themselves on the Pi but this software worked entirely as expected on the device so would suggest it be included upstream rather than folks that find this needing to add it on local forks.