### PR TITLE
Add the ability to reconfigure the Protect URL without resetting the credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ After configuration the app will automaticly start the liveview after startup. I
 - F9 Restart
 - F10 Restart & Reset
 - F11 Fullscreen (Electron, no Unifi Protect Fullscreen)
+- F12 Reconfigure URL (change the live stream URL without resetting credentials)
 
 ## Chrome App
 

--- a/main.js
+++ b/main.js
@@ -61,16 +61,16 @@ function handleConfigSave(event, config) {
 
 function handleUrlUpdate(event, newUrl) {
   const config = store.get('config');
-  if (config) {
+  if (config && newUrl) {
     config.url = newUrl;
     store.set('config', config);
   }
 }
 
 function handleShowReconfigureUrl() {
-  const mainWindow = BrowserWindow.getAllWindows()[0];
-  if (mainWindow) {
-    mainWindow.loadFile('./src/html/config.html', { query: { mode: 'reconfigure' } });
+  const windows = BrowserWindow.getAllWindows();
+  if (windows.length > 0) {
+    windows[0].loadFile('./src/html/config.html', { query: { mode: 'reconfigure' } });
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -59,6 +59,21 @@ function handleConfigSave(event, config) {
   store.set('config', config);
 }
 
+function handleUrlUpdate(event, newUrl) {
+  const config = store.get('config');
+  if (config) {
+    config.url = newUrl;
+    store.set('config', config);
+  }
+}
+
+function handleShowReconfigureUrl() {
+  const mainWindow = BrowserWindow.getAllWindows()[0];
+  if (mainWindow) {
+    mainWindow.loadFile('./src/html/config.html', { query: { mode: 'reconfigure' } });
+  }
+}
+
 // window handler
 async function handleWindow(mainWindow) {
   if (store.has('config')) {
@@ -132,6 +147,8 @@ app.whenReady().then(async () => {
   ipcMain.on('reset', handleReset);
   ipcMain.on('restart', handleRestart);
   ipcMain.on('configSave', handleConfigSave);
+  ipcMain.on('urlUpdate', handleUrlUpdate);
+  ipcMain.on('showReconfigureUrl', handleShowReconfigureUrl);
 
   ipcMain.handle('configLoad', handleConfigLoad)
 

--- a/src/html/config.html
+++ b/src/html/config.html
@@ -114,7 +114,7 @@
                 <div>
                     <h3>Unifi Protect Viewer</h3>
 
-                    <p>Please enter your configuration down below!</p>
+                    <p id="configMessage">Please enter your configuration down below!</p>
                 </div>
 
                 <div class="group">
@@ -122,20 +122,26 @@
                     <input id="url" name="url"/>
                 </div>
 
-                <div class="group">
-                    <label for="username">Username*</label>
-                    <input id="username" name="username"/>
-                </div>
+                <div id="credentialsSection">
+                    <div class="group">
+                        <label for="username">Username*</label>
+                        <input id="username" name="username"/>
+                    </div>
 
-                <div class="group">
-                    <label for="password">Password*</label>
-                    <input id="password" type="password" name="password"/>
+                    <div class="group">
+                        <label for="password">Password*</label>
+                        <input id="password" type="password" name="password"/>
+                    </div>
                 </div>
 
                 <div id="error" class="group error" style="display: none"></div>
 
-                <div class="group">
+                <div class="group" id="saveButtonContainer">
                     <button onclick="save()">Save Config</button>
+                </div>
+
+                <div class="group" id="cancelButtonContainer" style="display: none">
+                    <button onclick="cancel()" style="background-color: #6c757d; border-color: #6c757d;">Cancel</button>
                 </div>
 
                 <div>
@@ -144,6 +150,7 @@
                     <div class="hotkey"><small>F9</small><span>Restart</span></div>
                     <div class="hotkey"><small>F10</small><span>Reset & Restart</span></div>
                     <div class="hotkey"><small>F11</small><span>Fullscreen</span></div>
+                    <div class="hotkey"><small>F12</small><span>Reconfigure URL</span></div>
                 </div>
             </div>
 
@@ -153,11 +160,30 @@
         </div>
 
         <script type="text/javascript">
+            let isReconfigureMode = false;
+
+            // Check if we're in reconfigure mode on page load
+            document.addEventListener('DOMContentLoaded', async function() {
+                const urlParams = new URLSearchParams(window.location.search);
+                isReconfigureMode = urlParams.get('mode') === 'reconfigure';
+
+                if (isReconfigureMode) {
+                    // Load existing config and show current URL
+                    const config = await window.electronAPI.configLoad();
+                    if (config && config.url) {
+                        document.getElementById('url').value = config.url;
+                    }
+
+                    // Update UI for reconfigure mode
+                    document.getElementById('configMessage').innerText = 'Update your live stream URL below. Your credentials will be preserved.';
+                    document.getElementById('credentialsSection').style.display = 'none';
+                    document.getElementById('cancelButtonContainer').style.display = 'block';
+                    document.querySelector('#saveButtonContainer button').innerText = 'Update URL';
+                }
+            });
+
             function save() {
                 const url = document.getElementById("url").value;
-                const username = document.getElementById("username").value;
-                const password = document.getElementById("password").value;
-
                 const errorField = document.getElementById("error");
 
                 if (url === "") {
@@ -166,28 +192,43 @@
                     return;
                 }
 
-                if (username === "") {
-                    errorField.style.display = "initial";
-                    errorField.innerText = "The username is required!";
-                    return;
+                if (isReconfigureMode) {
+                    // Only update URL, preserve other settings
+                    errorField.style.display = "none";
+                    window.electronAPI.urlUpdate(url);
+                    window.electronAPI.restart();
+                } else {
+                    // Full config save (initial setup)
+                    const username = document.getElementById("username").value;
+                    const password = document.getElementById("password").value;
+
+                    if (username === "") {
+                        errorField.style.display = "initial";
+                        errorField.innerText = "The username is required!";
+                        return;
+                    }
+
+                    if (password === "") {
+                        errorField.style.display = "initial";
+                        errorField.innerText = "The password is required!";
+                        return;
+                    }
+
+                    const config = {
+                        url,
+                        username,
+                        password
+                    }
+
+                    errorField.style.display = "none";
+
+                    window.electronAPI.configSave(config);
+
+                    window.electronAPI.restart();
                 }
+            }
 
-                if (password === "") {
-                    errorField.style.display = "initial";
-                    errorField.innerText = "The password is required!";
-                    return;
-                }
-
-                const config = {
-                    url,
-                    username,
-                    password
-                }
-
-                errorField.style.display = "none";
-
-                window.electronAPI.configSave(config);
-
+            function cancel() {
                 window.electronAPI.restart();
             }
         </script>

--- a/src/html/config.html
+++ b/src/html/config.html
@@ -168,10 +168,14 @@
                 isReconfigureMode = urlParams.get('mode') === 'reconfigure';
 
                 if (isReconfigureMode) {
-                    // Load existing config and show current URL
-                    const config = await window.electronAPI.configLoad();
-                    if (config && config.url) {
-                        document.getElementById('url').value = config.url;
+                    try {
+                        // Load existing config and show current URL
+                        const config = await window.electronAPI.configLoad();
+                        if (config && config.url) {
+                            document.getElementById('url').value = config.url;
+                        }
+                    } catch (e) {
+                        // Config load failed, continue with empty URL field
                     }
 
                     // Update UI for reconfigure mode

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -80,6 +80,10 @@
                 <div class="group">
                     <button onclick="reset()">Reset Config</button>
                 </div>
+
+                <div class="group">
+                    <button onclick="reconfigureUrl()" style="background-color: #17a2b8; border-color: #17a2b8;">Reconfigure URL</button>
+                </div>
             </div>
 
             <div class="main">
@@ -92,6 +96,10 @@
                 window.electronAPI.reset();
 
                 window.electronAPI.restart();
+            }
+
+            function reconfigureUrl() {
+                window.electronAPI.showReconfigureUrl();
             }
         </script>
     </body>

--- a/src/js/preload.js
+++ b/src/js/preload.js
@@ -14,6 +14,9 @@ addEventListener('keydown', async (event) => {
         ipcRenderer.send('reset');
         ipcRenderer.send('restart');
     }
+    if (event.key === 'F12') {
+        ipcRenderer.send('showReconfigureUrl');
+    }
 });
 
 
@@ -21,6 +24,8 @@ addEventListener('keydown', async (event) => {
 const reset = () => ipcRenderer.send('reset');
 const restart = () => ipcRenderer.send('restart');
 const configSave = (config) => ipcRenderer.send('configSave', config);
+const urlUpdate = (url) => ipcRenderer.send('urlUpdate', url);
+const showReconfigureUrl = () => ipcRenderer.send('showReconfigureUrl');
 
 const configLoad = () => ipcRenderer.invoke('configLoad');
 
@@ -28,6 +33,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     reset: () => reset(),
     restart: () => restart(),
     configSave: (config) => configSave(config),
+    urlUpdate: (url) => urlUpdate(url),
+    showReconfigureUrl: () => showReconfigureUrl(),
 
     configLoad: () => configLoad(),
 })


### PR DESCRIPTION
This pull request introduces a new feature that allows users to reconfigure the live stream URL without resetting their credentials, accessible via a new F12 hotkey or a dedicated button in the UI. The update includes both backend and frontend changes to support this streamlined configuration flow, improving user experience for updating the stream URL.