### PR TITLE
Native UI ViewPort Emulation & Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A clean Electron app that auto-logs into your Unifi Protect instance and present
 - 🔐 **Auto-login** — credentials are stored securely and used on every start
 - 🖥️ **Fullscreen liveview** — all Unifi UI chrome is hidden automatically
 - 📋 **Multiple profiles** — save any number of NVRs or dashboards and switch between them instantly
+- 🖼️ **Viewport mode** — register the window as a Protect **Viewport** device and Share a Live View to it (follows re-shares natively)
 - ⚙️ **In-app configuration** — edit settings at any time without restarting (`F10` or tray menu)
 - 🔗 **URL-only mode** — quickly switch liveviews without re-entering credentials
 - 🔑 **Smart credential handling** — password is only overwritten when explicitly changed
@@ -78,6 +79,33 @@ Open the configuration editor (`F10` or tray → **Edit Configuration**).
 - **Set a startup profile** by enabling the **"Always start with this profile"** checkbox (only shown when more than one profile exists)
 
 ![Configuration – profile editor with sidebar](screenshots/configuration-connection.png)
+
+---
+
+## Viewport mode
+
+Viewport mode makes a viewer window act like a **UniFi Protect Viewport** — a display device your console can push camera views to. After it registers itself with Protect, you **Share a Live View** to it and the window shows that view fullscreen, automatically following whatever you re-share.
+
+**Requirements:** a UniFi OS console (UDM / UDM-Pro / UDM-SE / CloudKey Gen2+) running Protect **4.x – 7.x+**.
+
+### Enable it
+
+1. Open the configuration editor (`F10` or tray → **Edit Configuration**) and go to the **Viewport** tab.
+2. Turn on **Enable Viewport mode** and fill in:
+   - **NVR URL** — your Protect console address (the same one you open in a browser).
+   - **Username / Password** — an **admin** login. Used **once** to register the device, then to sign in automatically on each launch.
+   - **Device name** *(optional)* — how the Viewport appears under Protect → Devices. Defaults to `<HOSTNAME>_VIEWPORT`.
+   - **Fallback profile** *(optional)* — a normal profile to open if the Viewport can't connect at launch.
+3. Click **Save & Restart**.
+
+### Use it
+
+After the restart, open **Protect → Devices** — a new Viewport (your device name) appears. Use **Share with Viewport** (or assign a Live View to the device) and this window switches to it automatically, following any later re-share.
+
+### Security
+
+- Credentials are stored **encrypted on this device** (OS keychain via Electron `safeStorage`); where no keychain is available they are stored unencrypted with a clear in-app warning — prefer a dedicated, limited Protect account there. They are never sent anywhere except your own console.
+- The admin login registers the device only **once**. Afterwards the **device connection** reconnects without a password, using a self-adopted identity (key + pinned certificate) stored under the app's user-data directory. The saved login is still used to sign in to the Protect **web interface** on each launch — it is only ever sent to your own console.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
-        "electron-store": "8.2.0"
+        "electron-store": "8.2.0",
+        "selfsigned": "^2.4.1",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "cross-env": "10.1.0",
@@ -338,10 +340,18 @@
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -1962,6 +1972,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2449,6 +2468,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2740,7 +2772,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -2813,6 +2844,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
@@ -3105,9 +3157,16 @@
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-      "dev": true,
       "requires": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/responselike": {
@@ -4232,6 +4291,11 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -4582,6 +4646,15 @@
         "sprintf-js": "^1.1.2"
       }
     },
+    "selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "requires": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      }
+    },
     "semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4786,8 +4859,7 @@
     "undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -4838,6 +4910,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "requires": {}
     },
     "xmlbuilder": {
       "version": "15.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,9 +1140,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2758,9 +2758,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3692,9 +3692,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -4850,9 +4850,9 @@
       "optional": true
     },
     "undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   "author": "Sebastian Loer",
   "license": "MIT",
   "dependencies": {
-    "electron-store": "8.2.0"
+    "electron-store": "8.2.0",
+    "selfsigned": "^2.4.1",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "cross-env": "10.1.0",

--- a/src/html/config.html
+++ b/src/html/config.html
@@ -662,6 +662,22 @@
               </svg>
               Startup
             </button>
+            <button class="upv-content-tab" id="tabViewport" onclick="showTab('viewport')">
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+              Viewport
+            </button>
           </div>
 
           <!-- ─────────────────────────────────────────────────────────────── -->
@@ -1164,6 +1180,39 @@
                     </div>
                   </div>
                 </div>
+
+                <!-- ── Viewport pointer ────────────────────────────────────── -->
+                <div class="upv-info-card">
+                  <h4 class="upv-info-card__title">
+                    <svg
+                      width="11"
+                      height="11"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                    Viewport mode
+                  </h4>
+                  <p>
+                    Turn this window into a Protect
+                    <strong class="upv-text-primary">Viewport</strong> — share a Live View to it
+                    from Protect and it displays fullscreen, following any re-share.
+                  </p>
+                  <button
+                    class="upv-btn upv-btn--secondary"
+                    type="button"
+                    onclick="showTab('viewport')"
+                    style="margin-top: 4px"
+                  >
+                    Open the Viewport tab →
+                  </button>
+                </div>
               </div>
               <!-- /right -->
             </div>
@@ -1412,6 +1461,397 @@
             <!-- /grid -->
           </div>
           <!-- /panel startup -->
+          <!-- TAB: Viewport -->
+          <div class="upv-tab-panel" id="panelViewport">
+            <div class="upv-content-grid">
+              <!-- LEFT: Viewport mode card -->
+              <div>
+                <!-- Viewport mode -->
+                <div class="upv-cfg-card" id="viewport-group">
+                  <div class="upv-cfg-card__title">
+                    <svg
+                      width="13"
+                      height="13"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                    Viewport Mode
+                  </div>
+
+                  <label class="upv-toggle-row" for="viewport-enabled">
+                    <div class="upv-toggle-row__label">
+                      <span class="upv-toggle-row__title">Enable Viewport mode</span>
+                      <span class="upv-toggle-row__desc"
+                        >This window registers with Protect as a Viewport device and displays the
+                        Live View you share to it.</span
+                      >
+                    </div>
+                    <span class="upv-toggle">
+                      <input type="checkbox" id="viewport-enabled" />
+                      <span class="upv-toggle__track"></span>
+                    </span>
+                  </label>
+
+                  <div id="viewport-fields" style="display: none">
+                    <div
+                      class="upv-alert upv-alert--warn"
+                      id="viewport-encwarn"
+                      style="display: none"
+                    >
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                        <line x1="12" y1="8" x2="12" y2="12" />
+                        <line x1="12" y1="16" x2="12.01" y2="16" />
+                      </svg>
+                      <p>
+                        Your OS keychain isn't available, so the password will be saved unencrypted
+                        on this device. Prefer a dedicated, limited Protect account here.
+                      </p>
+                    </div>
+
+                    <div class="upv-field">
+                      <label class="upv-field__label" for="viewport-url">NVR URL</label>
+                      <div class="upv-input-wrap">
+                        <span class="upv-input-wrap__icon">
+                          <svg
+                            width="13"
+                            height="13"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                            <line x1="2" y1="12" x2="22" y2="12" />
+                            <path
+                              d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+                            />
+                          </svg>
+                        </span>
+                        <input
+                          class="upv-input"
+                          id="viewport-url"
+                          type="text"
+                          placeholder="https://192.168.1.1"
+                        />
+                      </div>
+                      <p class="upv-field__hint">
+                        The address of your Protect console — the same one you open in a browser.
+                        Used to register and sign in this Viewport.
+                      </p>
+                    </div>
+
+                    <div class="upv-field">
+                      <label class="upv-field__label" for="viewport-username">Username</label>
+                      <div class="upv-input-wrap">
+                        <span class="upv-input-wrap__icon">
+                          <svg
+                            width="13"
+                            height="13"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                            <circle cx="12" cy="7" r="4" />
+                          </svg>
+                        </span>
+                        <input
+                          class="upv-input"
+                          id="viewport-username"
+                          type="text"
+                          placeholder="admin"
+                          autocomplete="off"
+                        />
+                      </div>
+                    </div>
+
+                    <div class="upv-field">
+                      <label class="upv-field__label" for="viewport-password">
+                        Password
+                        <span
+                          class="upv-field__badge upv-field__badge--unchanged"
+                          id="viewport-passwordBadge"
+                          >unchanged</span
+                        >
+                      </label>
+                      <div class="upv-input-wrap">
+                        <span class="upv-input-wrap__icon">
+                          <svg
+                            width="13"
+                            height="13"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                          </svg>
+                        </span>
+                        <input
+                          class="upv-input"
+                          id="viewport-password"
+                          type="password"
+                          placeholder=""
+                          autocomplete="new-password"
+                        />
+                        <button
+                          class="upv-pw-toggle"
+                          id="viewport-togglePassword"
+                          type="button"
+                          title="Toggle visibility"
+                        >
+                          <svg
+                            id="viewport-eyeIcon"
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                            <circle cx="12" cy="12" r="3" />
+                          </svg>
+                        </button>
+                      </div>
+                      <p class="upv-field__hint">
+                        Used once to register this Viewport, then to sign in automatically each
+                        launch. Stored encrypted on this device — never sent anywhere else.
+                      </p>
+                    </div>
+
+                    <div class="upv-field">
+                      <label class="upv-field__label" for="viewport-name">Device name</label>
+                      <div class="upv-input-wrap">
+                        <span class="upv-input-wrap__icon">
+                          <svg
+                            width="13"
+                            height="13"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <path
+                              d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.83z"
+                            />
+                            <line x1="7" y1="7" x2="7.01" y2="7" />
+                          </svg>
+                        </span>
+                        <input class="upv-input" id="viewport-name" type="text" placeholder="" />
+                      </div>
+                      <p class="upv-field__hint">
+                        The name this Viewport shows under Protect → Devices. Leave blank to use the
+                        default shown above.
+                      </p>
+                      <div
+                        class="upv-alert upv-alert--warn"
+                        id="viewport-name-modelwarn"
+                        style="display: none"
+                      >
+                        <svg
+                          width="13"
+                          height="13"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <circle cx="12" cy="12" r="10" />
+                          <line x1="12" y1="8" x2="12" y2="12" />
+                          <line x1="12" y1="16" x2="12.01" y2="16" />
+                        </svg>
+                        <p>
+                          <strong>"UP Viewport"</strong> is Protect's default model name, so the
+                          rename will look like it did nothing. Pick a different name, or leave this
+                          blank to use the default shown above.
+                        </p>
+                      </div>
+                    </div>
+
+                    <div class="upv-field">
+                      <label class="upv-field__label" for="viewport-fallback"
+                        >Fallback profile</label
+                      >
+                      <div class="upv-input-wrap">
+                        <span class="upv-input-wrap__icon">
+                          <svg
+                            width="13"
+                            height="13"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <polygon points="5 3 19 12 5 21 5 3" />
+                          </svg>
+                        </span>
+                        <select class="upv-select" id="viewport-fallback">
+                          <option value="">None – no fallback</option>
+                        </select>
+                        <span class="upv-input-wrap__select-arrow">
+                          <svg
+                            width="11"
+                            height="11"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <polyline points="6 9 12 15 18 9" />
+                          </svg>
+                        </span>
+                      </div>
+                      <p class="upv-field__hint">
+                        If the Viewport can't connect at launch, open this profile instead.
+                      </p>
+                    </div>
+
+                    <p class="upv-field__hint" id="viewport-status-hint">
+                      Changes apply after a restart. Check status under Protect → Devices (or
+                      upv.log).
+                    </p>
+                    <div
+                      id="viewportMsg"
+                      class="upv-msg upv-msg--success"
+                      style="margin-bottom: 8px"
+                    >
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                      <span id="viewportMsgText"></span>
+                    </div>
+                    <div class="upv-btn-group">
+                      <button
+                        class="upv-btn upv-btn--primary"
+                        id="viewport-save-restart"
+                        type="button"
+                      >
+                        Save &amp; Restart
+                      </button>
+                      <button
+                        class="upv-btn upv-btn--secondary"
+                        id="viewport-save-only"
+                        type="button"
+                      >
+                        Save without restarting
+                      </button>
+                    </div>
+                    <button
+                      class="upv-btn upv-btn--secondary"
+                      id="viewport-remove"
+                      type="button"
+                      style="margin-top: 6px; display: none; color: var(--error-text)"
+                    >
+                      Remove this Viewport from Protect
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <!-- RIGHT: how-it-works explainer -->
+              <div>
+                <div class="upv-info-card" id="viewport-howto">
+                  <h4 class="upv-info-card__title">
+                    <svg
+                      width="11"
+                      height="11"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                      <circle cx="12" cy="12" r="3" />
+                    </svg>
+                    How Viewport mode works
+                  </h4>
+                  <p>
+                    Viewport mode makes this window act like a UniFi Protect Viewport — a display
+                    device your console can push camera views to. Once it's registered, you share a
+                    Live View to it from Protect and it shows that view fullscreen, following
+                    whatever you re-share.
+                  </p>
+                  <ol
+                    style="
+                      margin: 8px 0 6px;
+                      padding-left: 18px;
+                      font-size: 12px;
+                      line-height: 1.6;
+                      color: var(--text-secondary);
+                    "
+                  >
+                    <li>
+                      Fill in your console URL and an
+                      <strong class="upv-text-primary">admin</strong> login, then
+                      <strong class="upv-text-primary">Save &amp; Restart</strong>.
+                    </li>
+                    <li>
+                      In Protect, open <strong class="upv-text-primary">Devices</strong> — a new
+                      Viewport (your device name — default
+                      <code class="upv-code-inline">&lt;HOSTNAME&gt;_VIEWPORT</code>) appears.
+                    </li>
+                    <li>
+                      Use <strong class="upv-text-primary">Share with Viewport</strong> (or assign a
+                      Live View to the device) — this window switches to it automatically and
+                      follows any re-share.
+                    </li>
+                  </ol>
+                  <p class="upv-info-card__note">
+                    Only the first launch needs the admin login, to register the device; after that
+                    it signs in on its own using an identity stored on this machine. Requires a
+                    UniFi OS console running Protect 4.x–7.x+.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- /panel viewport -->
         </div>
         <!-- /main-inner -->
       </main>
@@ -1419,6 +1859,7 @@
     <!-- /layout -->
 
     <script src="debug-block.js"></script>
+    <script src="viewport-settings.js"></script>
     <script>
       // ── State ────────────────────────────────────────────────────────────────
       let currentMode = 'url';
@@ -1427,6 +1868,8 @@
       let originalUsername = '';
       let passwordChanged = false;
       let usernameChanged = false;
+      let vpPasswordChanged = false;
+      let vpRedacted = null;
 
       // ── Utilities ────────────────────────────────────────────────────────────
       function escHtml(s) {
@@ -1443,7 +1886,7 @@
 
       // ── Tab navigation ───────────────────────────────────────────────────────
       function showTab(tab) {
-        ['connection', 'startup'].forEach((t) => {
+        ['connection', 'startup', 'viewport'].forEach((t) => {
           document
             .getElementById('tab' + t.charAt(0).toUpperCase() + t.slice(1))
             .classList.toggle('upv-content-tab--active', t === tab);
@@ -1492,6 +1935,80 @@
         b.textContent = passwordChanged ? 'changed' : 'unchanged';
         b.className = 'upv-field__badge' + (passwordChanged ? '' : ' upv-field__badge--unchanged');
       });
+
+      // ── Viewport card listeners ──────────────────────────────────────────────
+      document.getElementById('viewport-togglePassword').addEventListener('click', function () {
+        const pw = document.getElementById('viewport-password');
+        const icon = document.getElementById('viewport-eyeIcon');
+        const hidden = pw.type === 'password';
+        pw.type = hidden ? 'text' : 'password';
+        icon.innerHTML = hidden
+          ? '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>'
+          : '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>';
+      });
+
+      document.getElementById('viewport-password').addEventListener('input', function () {
+        vpPasswordChanged = this.value.length > 0;
+        this.classList.toggle('upv-input--changed', vpPasswordChanged);
+        const b = document.getElementById('viewport-passwordBadge');
+        b.textContent = vpPasswordChanged ? 'changed' : 'unchanged';
+        b.className =
+          'upv-field__badge' + (vpPasswordChanged ? '' : ' upv-field__badge--unchanged');
+      });
+
+      // "UP Viewport" is Protect's default model name, so renaming to it looks like a no-op.
+      function refreshViewportNameModelWarn() {
+        const isModelName =
+          document.getElementById('viewport-name').value.trim().toLowerCase() === 'up viewport';
+        document.getElementById('viewport-name-modelwarn').style.display = isModelName
+          ? 'flex'
+          : 'none';
+      }
+      document
+        .getElementById('viewport-name')
+        .addEventListener('input', refreshViewportNameModelWarn);
+
+      document.getElementById('viewport-enabled').addEventListener('change', function () {
+        document.getElementById('viewport-fields').style.display = this.checked ? 'block' : 'none';
+      });
+
+      document.getElementById('viewport-save-restart').addEventListener('click', function () {
+        if (saveViewport()) window.electronAPI.restart();
+      });
+      document.getElementById('viewport-save-only').addEventListener('click', function () {
+        saveViewport();
+      });
+
+      // Two-click confirm: first click arms, second click actually removes.
+      let vpRemoveArmed = false;
+      const VP_REMOVE_LABEL = 'Remove this Viewport from Protect';
+      const vpRemoveBtn = document.getElementById('viewport-remove');
+      if (vpRemoveBtn)
+        vpRemoveBtn.addEventListener('click', async () => {
+          if (!vpRemoveArmed) {
+            vpRemoveArmed = true;
+            vpRemoveBtn.textContent = 'Click again to confirm removal';
+            return;
+          }
+          vpRemoveBtn.disabled = true;
+          vpRemoveBtn.textContent = 'Removing…';
+          let res;
+          try {
+            res = await window.electronAPI.viewportRemove();
+          } catch (e) {
+            res = { ok: false, message: (e && e.message) || 'unknown' };
+          }
+          const msgEl = document.getElementById('viewportMsg');
+          document.getElementById('viewportMsgText').textContent =
+            res && res.ok
+              ? res.message + ' Restart to finish.'
+              : 'Remove failed: ' + ((res && res.message) || 'unknown');
+          msgEl.className =
+            'upv-msg upv-msg--' + (res && res.ok ? 'success' : 'error') + ' upv-msg--visible';
+          vpRemoveBtn.disabled = false;
+          vpRemoveArmed = false;
+          vpRemoveBtn.textContent = VP_REMOVE_LABEL;
+        });
 
       // ── Profile list ──────────────────────────────────────────────────────────
       function renderProfileList() {
@@ -1578,6 +2095,7 @@
         renderProfileList();
         loadProfileIntoForm(newP.id);
         refreshStartupProfileDropdown();
+        refreshViewportFallbackDropdown();
         document.getElementById('profileName').focus();
       }
 
@@ -1593,6 +2111,7 @@
         renderProfileList();
         loadProfileIntoForm(activeProfileId);
         refreshStartupProfileDropdown();
+        refreshViewportFallbackDropdown();
       }
 
       // ── Messages ──────────────────────────────────────────────────────────────
@@ -1742,6 +2261,19 @@
         if (prev && profiles.find((p) => p.id === prev)) sel.value = prev;
       }
 
+      function refreshViewportFallbackDropdown(selectedId) {
+        const sel = document.getElementById('viewport-fallback');
+        const prev = selectedId !== undefined ? selectedId : sel.value;
+        sel.innerHTML = '<option value="">None – no fallback</option>';
+        profiles.forEach((p) => {
+          const opt = document.createElement('option');
+          opt.value = p.id;
+          opt.textContent = p.name || 'Unnamed Profile';
+          sel.appendChild(opt);
+        });
+        if (prev && profiles.find((p) => p.id === prev)) sel.value = prev;
+      }
+
       async function loadStartupTab() {
         const settings = await window.electronAPI.startupSettingsGet();
         refreshStartupProfileDropdown(settings.profileId || '');
@@ -1750,6 +2282,41 @@
           ? 'block'
           : 'none';
         await refreshDisplayDropdown(settings.displayIndex ?? 0);
+      }
+
+      // ── Viewport tab ──────────────────────────────────────────────────────────
+      async function loadViewportTab() {
+        vpRedacted = await window.electronAPI.viewportConfigGet();
+        const vpForm = window.viewportSettings.viewportFormFromConfig(vpRedacted);
+        document.getElementById('viewport-enabled').checked = vpForm.enabled;
+        document.getElementById('viewport-fields').style.display = vpForm.enabled
+          ? 'block'
+          : 'none';
+        document.getElementById('viewport-url').value = vpForm.url;
+        document.getElementById('viewport-username').value = vpForm.username;
+        const vpPw = document.getElementById('viewport-password');
+        vpPw.value = '';
+        vpPw.placeholder = vpForm.passwordPlaceholder;
+        vpPasswordChanged = false;
+        vpPw.classList.remove('upv-input--changed');
+        document.getElementById('viewport-passwordBadge').textContent = 'unchanged';
+        document.getElementById('viewport-passwordBadge').className =
+          'upv-field__badge upv-field__badge--unchanged';
+        document.getElementById('viewport-name').value = vpForm.name;
+        document.getElementById('viewport-name').placeholder = vpForm.namePlaceholder;
+        refreshViewportFallbackDropdown(vpForm.fallbackProfileId);
+        document.getElementById('viewport-encwarn').style.display = vpForm.showEncWarning
+          ? 'flex'
+          : 'none';
+        // Remove button only makes sense once a viewport is configured.
+        const removeBtn = document.getElementById('viewport-remove');
+        if (removeBtn) {
+          removeBtn.style.display = vpForm.enabled || vpRedacted.hasPassword ? 'flex' : 'none';
+          removeBtn.disabled = false;
+          removeBtn.textContent = 'Remove this Viewport from Protect';
+          vpRemoveArmed = false;
+        }
+        refreshViewportNameModelWarn();
       }
 
       async function refreshDisplayDropdown(selectedIndex) {
@@ -1789,6 +2356,35 @@
         setTimeout(() => msgEl.classList.remove('upv-msg--visible'), 3000);
       }
 
+      function saveViewport() {
+        const vpForm = {
+          enabled: document.getElementById('viewport-enabled').checked,
+          name: document.getElementById('viewport-name').value,
+          url: document.getElementById('viewport-url').value,
+          username: document.getElementById('viewport-username').value,
+          passwordValue: document.getElementById('viewport-password').value,
+          passwordChanged: vpPasswordChanged,
+          fallbackProfileId: document.getElementById('viewport-fallback').value,
+        };
+        const check = window.viewportSettings.validateViewportForm(vpForm, vpRedacted);
+        const msgEl = document.getElementById('viewportMsg');
+        if (!check.ok) {
+          document.getElementById('viewportMsgText').textContent = check.error;
+          msgEl.className = 'upv-msg upv-msg--error upv-msg--visible';
+          const bad = document.getElementById(check.field);
+          if (bad) bad.focus();
+          return false;
+        }
+        window.electronAPI.viewportConfigSet(
+          window.viewportSettings.buildViewportSetPayload(vpForm),
+        );
+        document.getElementById('viewportMsgText').textContent =
+          'Saved. Restart to apply Viewport changes.';
+        msgEl.className = 'upv-msg upv-msg--success upv-msg--visible';
+        setTimeout(() => msgEl.classList.remove('upv-msg--visible'), 3000);
+        return true;
+      }
+
       // ── Init ──────────────────────────────────────────────────────────────────
       window.addEventListener('DOMContentLoaded', async () => {
         renderDebugBlock(document.getElementById('debugBlockContainer'));
@@ -1812,6 +2408,7 @@
           renderProfileList();
           loadProfileIntoForm(activeProfileId);
           await loadStartupTab();
+          await loadViewportTab();
 
           // Show "← Profile Selection" nav link when multiple profiles are configured
           if (profiles.length > 1) {

--- a/src/html/config.html
+++ b/src/html/config.html
@@ -2317,6 +2317,9 @@
           vpRemoveArmed = false;
         }
         refreshViewportNameModelWarn();
+        // Report whether Viewport mode is enabled so the caller can decide which
+        // tab to land on (viewport-mode users should open straight to Viewport).
+        return vpForm.enabled;
       }
 
       async function refreshDisplayDropdown(selectedIndex) {
@@ -2408,7 +2411,14 @@
           renderProfileList();
           loadProfileIntoForm(activeProfileId);
           await loadStartupTab();
-          await loadViewportTab();
+          const viewportEnabled = await loadViewportTab();
+
+          // When this window is running as a Viewport, open the settings straight
+          // to the Viewport tab — that's the context the user came to manage.
+          // Otherwise keep the default Connection tab (already active in markup).
+          if (viewportEnabled) {
+            showTab('viewport');
+          }
 
           // Show "← Profile Selection" nav link when multiple profiles are configured
           if (profiles.length > 1) {

--- a/src/html/config.html
+++ b/src/html/config.html
@@ -1463,6 +1463,15 @@
           <!-- /panel startup -->
           <!-- TAB: Viewport -->
           <div class="upv-tab-panel" id="panelViewport">
+            <!-- Registration-failure banner (populated on load from the ?vp-error
+                 query when startViewportBridge bounces back here on a fatal
+                 adoption error, e.g. wrong admin username/password). -->
+            <div id="viewport-error-banner" class="upv-msg upv-msg--error" role="alert">
+              <div>
+                <strong id="viewport-error-title"></strong>
+                <div id="viewport-error-detail" style="margin-top: 2px"></div>
+              </div>
+            </div>
             <div class="upv-content-grid">
               <!-- LEFT: Viewport mode card -->
               <div>
@@ -2413,10 +2422,22 @@
           await loadStartupTab();
           const viewportEnabled = await loadViewportTab();
 
-          // When this window is running as a Viewport, open the settings straight
-          // to the Viewport tab — that's the context the user came to manage.
-          // Otherwise keep the default Connection tab (already active in markup).
-          if (viewportEnabled) {
+          // If startViewportBridge bounced us back here on a FATAL adoption error
+          // (e.g. wrong admin username/password), notify the user WHY instead of
+          // silently reopening the Viewport tab. The reason arrives on ?vp-error.
+          const vpError = new URLSearchParams(window.location.search).get('vp-error');
+          const vpBanner = vpError && window.viewportSettings.adoptionErrorBanner(vpError);
+          if (vpBanner) {
+            document.getElementById('viewport-error-title').textContent = vpBanner.title;
+            document.getElementById('viewport-error-detail').textContent = vpBanner.detail;
+            document.getElementById('viewport-error-banner').classList.add('upv-msg--visible');
+          }
+
+          // When this window is running as a Viewport (or bounced back here with a
+          // registration error to explain), open straight to the Viewport tab —
+          // that's the context the user came to manage. Otherwise keep the default
+          // Connection tab (already active in markup).
+          if (viewportEnabled || vpBanner) {
             showTab('viewport');
           }
 

--- a/src/html/config.html
+++ b/src/html/config.html
@@ -1856,6 +1856,25 @@
                     it signs in on its own using an identity stored on this machine. Requires a
                     UniFi OS console running Protect 4.x–7.x+.
                   </p>
+                  <p class="upv-info-card__note">
+                    <strong class="upv-text-primary">Shared multiviews:</strong> Viewport mode keeps
+                    <strong class="upv-text-primary">"Show Shared Multiviews"</strong> enabled on
+                    this account each launch, so a shared/public multiview you assign displays
+                    instead of falling back to
+                    <strong class="upv-text-primary">All Cameras</strong>.
+                  </p>
+                  <!-- Shown only when the per-launch auto-enable actually ran and failed. -->
+                  <div
+                    id="viewport-sharedviews-warn"
+                    class="upv-msg upv-msg--error"
+                    role="alert"
+                    style="margin-top: 8px"
+                  >
+                    <div>
+                      <strong>Couldn't confirm "Show Shared Multiviews" for this account.</strong>
+                      <div id="viewport-sharedviews-warn-detail" style="margin-top: 2px"></div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -2326,9 +2345,34 @@
           vpRemoveArmed = false;
         }
         refreshViewportNameModelWarn();
+        await refreshSharedViewsWarning();
         // Report whether Viewport mode is enabled so the caller can decide which
         // tab to land on (viewport-mode users should open straight to Viewport).
         return vpForm.enabled;
+      }
+
+      // Shows a warning only when THIS launch's best-effort "Show Shared
+      // Multiviews" auto-enable actually ran and failed — so a shared multiview
+      // silently showing as All Cameras is explained rather than mysterious.
+      async function refreshSharedViewsWarning() {
+        const warn = document.getElementById('viewport-sharedviews-warn');
+        if (!warn) return;
+        try {
+          const sv = await window.electronAPI.viewportSharedViewsStatus();
+          if (sv && sv.ran && !sv.ok) {
+            document.getElementById('viewport-sharedviews-warn-detail').textContent =
+              sv.reason === 'read'
+                ? 'The app couldn’t read this account’s settings — check the admin username/password or its permissions.'
+                : sv.reason === 'patch'
+                  ? 'The console rejected the change — this account may lack permission to change its own settings.'
+                  : 'Enable “Show Shared Multiviews” in Protect (as this account) if a shared view shows as All Cameras.';
+            warn.classList.add('upv-msg--visible');
+          } else {
+            warn.classList.remove('upv-msg--visible');
+          }
+        } catch (e) {
+          warn.classList.remove('upv-msg--visible'); // status is best-effort
+        }
       }
 
       async function refreshDisplayDropdown(selectedIndex) {

--- a/src/html/viewport-settings.js
+++ b/src/html/viewport-settings.js
@@ -1,0 +1,88 @@
+/**
+ * @file viewport-settings.js
+ * @description Pure form↔config mapping for the Viewport card on config.html's
+ * Startup tab. NO DOM access here — config.html wires these to its elements.
+ * Unit-tested in test/js/viewport-settings.test.js (vm sandbox).
+ *
+ * Usage:
+ *   <script src="viewport-settings.js"></script>
+ *   window.viewportSettings.viewportFormFromConfig(redacted) → form state
+ *   window.viewportSettings.validateViewportForm(form, redacted) → {ok,...}
+ *   window.viewportSettings.buildViewportSetPayload(form) → viewportConfigSet payload
+ */
+
+(function () {
+  'use strict';
+
+  /** Maps the redacted config (viewportConfigGet) to display/form state. */
+  function viewportFormFromConfig(redacted) {
+    const r = redacted || {};
+    return {
+      enabled: !!r.enabled,
+      name: r.name || '',
+      url: r.url || '',
+      username: r.username || '',
+      fallbackProfileId: r.fallbackProfileId || '',
+      namePlaceholder: r.defaultName || '',
+      passwordPlaceholder: r.hasPassword ? 'unchanged' : '',
+      showEncWarning: r.encryptionAvailable === false,
+    };
+  }
+
+  /**
+   * Validates the form before save. Returns { ok:true } or
+   * { ok:false, error, field } where field is the input element id.
+   * Credentials are REQUIRED in Viewport mode: they drive both the one-time
+   * adopt and the silent render auto-login on every launch.
+   */
+  function validateViewportForm(form, redacted) {
+    if (!form.enabled) return { ok: true };
+    const url = (form.url || '').trim();
+    if (!url) {
+      return { ok: false, error: 'NVR URL is required for Viewport mode.', field: 'viewport-url' };
+    }
+    if (!/^https?:\/\//.test(url)) {
+      return {
+        ok: false,
+        error: 'NVR URL must start with https:// or http://',
+        field: 'viewport-url',
+      };
+    }
+    if (!(form.username || '').trim()) {
+      return {
+        ok: false,
+        error: 'Username is required for Viewport mode.',
+        field: 'viewport-username',
+      };
+    }
+    const hasStored = !!(redacted && redacted.hasPassword);
+    const passwordOk = form.passwordChanged ? !!form.passwordValue : hasStored;
+    if (!passwordOk) {
+      return {
+        ok: false,
+        error: 'Password is required for Viewport mode.',
+        field: 'viewport-password',
+      };
+    }
+    return { ok: true };
+  }
+
+  /** Builds the viewportConfigSet payload from form state. */
+  function buildViewportSetPayload(form) {
+    return {
+      enabled: !!form.enabled,
+      name: (form.name || '').trim(),
+      url: (form.url || '').trim(),
+      username: (form.username || '').trim(),
+      password: form.passwordChanged ? form.passwordValue : '',
+      passwordChanged: !!form.passwordChanged,
+      fallbackProfileId: form.fallbackProfileId || null,
+    };
+  }
+
+  window.viewportSettings = {
+    viewportFormFromConfig,
+    validateViewportForm,
+    buildViewportSetPayload,
+  };
+})();

--- a/src/html/viewport-settings.js
+++ b/src/html/viewport-settings.js
@@ -80,9 +80,38 @@
     };
   }
 
+  /**
+   * Maps a Viewport-registration failure code (passed to config.html on the
+   * `vp-error` query param when startViewportBridge hits a FATAL adoption error
+   * with no usable fallback) to a human banner. Returns null for an
+   * absent/unknown code so the caller shows nothing.
+   *   'auth'   → the console rejected the admin username/password (401/403)
+   *   'failed' → any other fatal registration failure
+   */
+  function adoptionErrorBanner(code) {
+    if (code === 'auth') {
+      return {
+        title: 'Viewport registration failed',
+        detail:
+          'The console rejected the admin username or password for this Viewport. ' +
+          'Re-enter them below, then Save & Restart.',
+      };
+    }
+    if (code === 'failed') {
+      return {
+        title: 'Viewport registration failed',
+        detail:
+          'This window could not register as a Viewport. Check the NVR address and ' +
+          'admin credentials below, then Save & Restart.',
+      };
+    }
+    return null;
+  }
+
   window.viewportSettings = {
     viewportFormFromConfig,
     validateViewportForm,
     buildViewportSetPayload,
+    adoptionErrorBanner,
   };
 })();

--- a/src/js/liveview/overlay.js
+++ b/src/js/liveview/overlay.js
@@ -97,4 +97,40 @@ function hideOverlay(reason = 'done') {
   }, 450);
 }
 
+// ── Viewport adoption status → overlay copy ──────────────────────────────────
+// REFERENCE ONLY — the runtime subscription lives inlined in src/js/preload.js
+// (this file is the reviewable source copy; preload.js is what actually runs).
+//
+// In viewport adoption mode, main pushes 'viewportStatus' with
+// 'registering' | 'online-unassigned' | 'reconnecting' | 'assigned' while the
+// UCP device connection walks the adoption flow (see src/main/window.js). All
+// but 'assigned' override the overlay copy; 'assigned' is intentionally
+// ignored — from there the normal liveview automation drives the overlay text.
+//
+// Notes (mirrored from preload.js):
+//  - preload.js subscribes directly on its `ipc` IPC helper: with
+//    contextIsolation, window.electronAPI only exists in the page's main
+//    world, not in the preload's isolated world. The equivalent bridge
+//    binding (electronAPI.onViewportStatus) is exposed for main-world pages.
+//  - setOverlayStatus() safely no-ops until showOverlay() has created the
+//    overlay, and profile mode never receives the channel → inert there.
+//  - A reconnect may re-send 'online-unassigned' after 'assigned'; page
+//    navigation resets the overlay, so plain text updates are all we need.
+//
+// Wrapped in a function here (unlike the inlined top-level statement in
+// preload.js) so this reference file stays free of undeclared globals.
+// @param {{ on:(channel:string, listener:Function)=>void }} ipc – preload's IPC helper
+function bindViewportStatusToOverlay(ipc) {
+  ipc.on('viewportStatus', (_event, state) => {
+    if (state === 'registering') {
+      setOverlayStatus('Registering Viewport…', 'Contacting your Protect console');
+    } else if (state === 'online-unassigned') {
+      setOverlayStatus('Viewport online', 'Assign a Live View to it in Protect → Devices');
+    } else if (state === 'reconnecting') {
+      setOverlayStatus('Viewport offline', 'Reconnecting to your console…');
+    }
+    // 'assigned' → the normal liveview loading flow drives the text.
+  });
+}
+
 // (no module.exports – this file is a reference copy, not a runtime module)

--- a/src/js/preload.js
+++ b/src/js/preload.js
@@ -70,6 +70,7 @@ const logo128 =
 const ipc = {
   send: (channel, ...args) => ipcRenderer.send(channel, ...args),
   invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
+  on: (channel, listener) => ipcRenderer.on(channel, listener),
 };
 
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -109,6 +110,34 @@ contextBridge.exposeInMainWorld('electronAPI', {
   startupSettingsGet: () => ipc.invoke('startupSettingsGet'),
   /** Persists (merges) the global startup settings. */
   startupSettingsSet: (settings) => ipc.send('startupSettingsSet', settings),
+  /**
+   * Returns the REDACTED viewport config for the settings UI:
+   * { enabled, name, url, username, fallbackProfileId, hasPassword,
+   *   encryptionAvailable, defaultName } — the password never crosses to the renderer.
+   */
+  viewportConfigGet: () => ipc.invoke('viewportConfigGet'),
+  /**
+   * Persists (merges) the viewport config. Include passwordChanged:true to
+   * (re-)encrypt `password` in main; omit it to keep the stored secret.
+   *
+   * FOOTGUN: passwordChanged:true with a missing/empty `password` CLEARS the
+   * stored password. Only send passwordChanged:true together with the actual
+   * new password value; for an unchanged password omit the flag (or send
+   * false) so the store keeps the existing ciphertext.
+   */
+  viewportConfigSet: (settings) => ipc.send('viewportConfigSet', settings),
+  /**
+   * Removes this Viewport from Protect: deletes the adopted device via the
+   * admin API, resets the local identity and disables viewport mode.
+   * Resolves to { ok, removed, message }.
+   */
+  viewportRemove: () => ipc.invoke('viewportRemove'),
+  /**
+   * Subscribes to viewport adoption-state pushes from main
+   * ('registering' | 'online-unassigned' | 'assigned'). Only sent in viewport
+   * adoption mode; profile mode never receives this channel.
+   */
+  onViewportStatus: (cb) => ipc.on('viewportStatus', (_e, s) => cb(s)),
   /** Returns a list of all connected displays with index, label and bounds. */
   displaysGet: () => ipc.invoke('displaysGet'),
   /** Cycles to the next profile (F10). */
@@ -167,7 +196,18 @@ window.addEventListener(
  * fullscreen handler. Also manages the loading overlay lifecycle.
  */
 async function startLiveviewAutomation() {
+  // configLoad returns the EFFECTIVE render connection: the active profile, or —
+  // in Viewport mode — the dedicated viewport connection (ipc.js decides). The
+  // auto-login below and the unexpected-URL redirect both key off this object.
   const config = await ipc.invoke('configLoad');
+
+  // Viewport mode: configLoad carries viewportName only for the dedicated
+  // viewport connection (ipc.js). When set, the loading overlay shows
+  // "Loading Viewport" + the viewport's name instead of the profile-mode
+  // "Loading cameras…" + stage detail — profile mode is unaffected.
+  const vpName = config && config.viewportName;
+  const loadingText = (stage) =>
+    vpName ? ['Loading Viewport', vpName] : ['Loading cameras…', stage];
 
   // Skip automation on our own HTML pages
   if (
@@ -220,19 +260,19 @@ async function startLiveviewAutomation() {
     console.log('[upv] login successful – now at:', document.URL);
   }
 
-  setOverlayStatus('Loading cameras\u2026', 'Preparing liveview');
+  setOverlayStatus(...loadingText('Preparing liveview'));
 
   // ── Protect 2.x ──────────────────────────────────────────────────────────
   if (currentUrlIncludes('protect/liveview')) {
     console.log('[upv] URL pattern "protect/liveview" → Protect 2.x handler');
-    setOverlayStatus('Loading cameras\u2026', 'Applying Protect 2.x layout');
+    setOverlayStatus(...loadingText('Applying Protect 2.x layout'));
     await applyLiveviewV2();
     hideOverlay('v2 ready');
     return;
   }
 
   // ── Detect version string (Protect 4+ renders it; 3.x does not) ──────────
-  setOverlayStatus('Loading cameras\u2026', 'Detecting Protect version');
+  setOverlayStatus(...loadingText('Detecting Protect version'));
   console.log('[upv] waiting for version string in footer (timeout 10 s)');
   const versionFound = await waitUntil(
     () => document.querySelectorAll('[class^=Version__Item] > span').length > 0,
@@ -259,11 +299,11 @@ async function startLiveviewAutomation() {
     protectVersion &&
     isLegacyVersion3(protectVersion)
   ) {
-    setOverlayStatus('Loading cameras\u2026', 'Applying Protect 3.x layout');
+    setOverlayStatus(...loadingText('Applying Protect 3.x layout'));
     console.log('[upv] applying Protect 3.x liveview handler (pass 1)');
     await applyLiveviewV3();
     console.log('[upv] pass 1 done – waiting 4 s for lazy-rendered elements');
-    setOverlayStatus('Loading cameras\u2026', 'Waiting for lazy camera slots');
+    setOverlayStatus(...loadingText('Waiting for lazy camera slots'));
     await wait(4_000);
     console.log('[upv] applying Protect 3.x liveview handler (pass 2 – lazy elements)');
     await applyLiveviewV3();
@@ -277,11 +317,11 @@ async function startLiveviewAutomation() {
     currentUrlIncludes('protect/dashboard') &&
     isModernVersion(protectVersion)
   ) {
-    setOverlayStatus('Loading cameras\u2026', `Applying Protect ${protectVersion} layout`);
+    setOverlayStatus(...loadingText(`Applying Protect ${protectVersion} layout`));
     console.log('[upv] applying Protect 4.x+ liveview handler (pass 1)');
     await applyLiveviewV4andNewer();
     console.log('[upv] pass 1 done – waiting 4 s for lazy-rendered elements');
-    setOverlayStatus('Loading cameras\u2026', 'Waiting for lazy camera slots');
+    setOverlayStatus(...loadingText('Waiting for lazy camera slots'));
     await wait(4_000);
     console.log('[upv] applying Protect 4.x+ liveview handler (pass 2 – lazy elements)');
     await applyLiveviewV4andNewer();
@@ -453,6 +493,39 @@ function hideOverlay(reason = 'done') {
     document.getElementById(OVERLAY_IDS.overlay)?.remove();
     document.getElementById(OVERLAY_IDS.style)?.remove();
   }, 450);
+}
+
+// ── Viewport adoption status → overlay copy ──────────────────────────────────
+// In viewport adoption mode, main pushes 'viewportStatus' with
+// 'registering' | 'online-unassigned' | 'reconnecting' | 'assigned' while the
+// UCP device connection walks the adoption flow (see src/main/window.js). Map
+// all but 'assigned' onto the loading overlay; 'assigned' is intentionally
+// ignored — from there the normal liveview automation drives the overlay text.
+//
+// Notes:
+//  - Subscribed directly on the preload's ipc handle: with contextIsolation,
+//    window.electronAPI only exists in the page's main world, not here. The
+//    equivalent bridge binding (electronAPI.onViewportStatus) is exposed for
+//    main-world pages.
+//  - setOverlayStatus() safely no-ops until showOverlay() has created the
+//    overlay, and profile mode never receives the channel → inert there.
+//  - A reconnect may re-send 'online-unassigned' after 'assigned'; page
+//    navigation resets the overlay, so plain text updates are all we need.
+//  - typeof guard: real Electron always provides ipcRenderer.on; the test
+//    sandboxes' ipcRenderer mock only stubs send/invoke, and a throw here
+//    would abort script-level init (version-resolution.test.js appends a
+//    capture call to this source that must still run).
+if (typeof ipcRenderer.on === 'function') {
+  ipc.on('viewportStatus', (_event, state) => {
+    if (state === 'registering') {
+      setOverlayStatus('Registering Viewport…', 'Contacting your Protect console');
+    } else if (state === 'online-unassigned') {
+      setOverlayStatus('Viewport online', 'Assign a Live View to it in Protect → Devices');
+    } else if (state === 'reconnecting') {
+      setOverlayStatus('Viewport offline', 'Reconnecting to your console…');
+    }
+    // 'assigned' → the normal liveview loading flow drives the text.
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/js/preload.js
+++ b/src/js/preload.js
@@ -133,6 +133,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
    */
   viewportRemove: () => ipc.invoke('viewportRemove'),
   /**
+   * This launch's best-effort "Show Shared Multiviews" auto-enable outcome
+   * ({ ran, ok, reason }), so the Viewport settings can warn if it couldn't run.
+   */
+  viewportSharedViewsStatus: () => ipc.invoke('viewportSharedViewsStatus'),
+  /**
    * Subscribes to viewport adoption-state pushes from main
    * ('registering' | 'online-unassigned' | 'assigned'). Only sent in viewport
    * adoption mode; profile mode never receives this channel.

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -19,6 +19,40 @@ app.commandLine.appendSwitch('ignore-certificate-errors', 'true');
 // ── Remove default menu (disables native F11 accelerator and menu bar) ────────
 Menu.setApplicationMenu(null);
 
+// ── Single-instance lock ───────────────────────────────────────────────────────
+// Without this, launching the app a second time (or a stray double-click while
+// it's already running) spawns a second process sharing the same userData —
+// same viewport device identity/MAC, same upv.log. In Viewport mode each
+// instance runs its own AdoptionClient, so two instances adopt as the SAME MAC
+// and fight each other on the NVR (duplicate "adoption client starting" log
+// lines). requestSingleInstanceLock() must be called synchronously, before
+// app.whenReady(), so a second launch can be detected and turned away before
+// it does any startup work.
+const gotLock = app.requestSingleInstanceLock();
+
+if (!gotLock) {
+  // Another instance already holds the lock – hand off to it and exit
+  // immediately. Do NOT fall through to whenReady(): that would start a
+  // second AdoptionClient/window. This mirrors app.exit(0) semantics closely
+  // enough for a duplicate manual launch (nothing has been set up yet to
+  // clean up), and matches the standard Electron single-instance pattern.
+  app.quit();
+  return;
+}
+
+// This instance holds the lock. A second launch attempt (detected above, in
+// the *other* process) redirects here instead of starting its own window –
+// surface the window we already have instead of silently doing nothing.
+app.on('second-instance', () => {
+  const { BrowserWindow } = require('electron');
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win) {
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+  }
+});
+
 // ── App lifecycle ─────────────────────────────────────────────────────────────
 
 // Logger is created once the app is ready (userData path available then).

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -238,9 +238,19 @@ async function onViewportRemove() {
 }
 
 /**
+ * Returns this launch's best-effort "Show Shared Multiviews" auto-enable outcome
+ * ({ ran, ok, reason }) so the Viewport settings can warn only when it actually
+ * ran and failed. Set by window.js from the AdoptionClient's `sharedViews` event.
+ */
+async function onViewportSharedViewsStatus() {
+  return require('./viewport/shared-views-status').get();
+}
+
+/**
  * Returns a simplified list of all connected displays for the config UI.
  * Electron's display objects are not fully serialisable, so we map to a plain array.
  */
+
 async function onDisplaysGet() {
   const displays = screen.getAllDisplays();
   const primary = screen.getPrimaryDisplay();
@@ -346,6 +356,7 @@ function registerIpcHandlers(getLogger) {
   ipcMain.handle('startupSettingsGet', onStartupSettingsGet);
   ipcMain.handle('viewportConfigGet', onViewportConfigGet);
   ipcMain.handle('viewportRemove', onViewportRemove);
+  ipcMain.handle('viewportSharedViewsStatus', onViewportSharedViewsStatus);
   ipcMain.handle('displaysGet', onDisplaysGet);
 }
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -7,7 +7,9 @@
 
 const { ipcMain, BrowserWindow, shell, screen } = require('electron');
 const path = require('node:path');
+const os = require('node:os');
 const store = require('./store');
+const renderSession = require('./render-session');
 const { LOG_IPC_CHANNEL, LOG_SOURCE_WINDOW, LOG_SOURCE_APP } = require('./logger');
 
 // ── Handler implementations ───────────────────────────────────────────────────
@@ -16,7 +18,12 @@ function onReset() {
   store.clearAll();
   const { app } = require('electron');
   app.relaunch();
-  app.quit();
+  // exit(0), not quit(): with the single-instance lock, the relaunched instance
+  // must be able to acquire the lock, which requires this process to release it
+  // promptly. app.exit(0) terminates immediately; app.quit() is graceful and can
+  // still hold the lock when the new instance starts (→ reset would just close
+  // the app). Nothing needs a graceful close here — clearAll() already ran.
+  app.exit(0);
 }
 
 function onRestart(event) {
@@ -36,6 +43,28 @@ function onConfigSave(_event, config) {
 }
 
 async function onConfigLoad() {
+  // Render-session override: once window.js
+  // has fallen back from a failed Viewport-mode adoption to a configured
+  // profile, this in-memory override takes priority over everything below —
+  // otherwise the viewport-connection gate stays true (the store's `enabled`
+  // flag is untouched by a fallback) and the render session would keep
+  // authenticating as the viewport connection even though the window has
+  // navigated to the fallback profile.
+  const override = renderSession.getRenderCredentialOverride();
+  if (override) return override;
+
+  // Viewport mode: the render web-session authenticates with the DEDICATED
+  // viewport connection — the preload's auto-login and unexpected-URL redirect
+  // both read this object, so returning the connection here switches the
+  // credential source without any renderer changes.
+  const vp = store.getViewportConfig();
+  if (vp.enabled && vp.url) {
+    // viewportName drives the "Loading Viewport" overlay sub-line (preload.js):
+    // the configured name, or the same `<hostname>_VIEWPORT` default shown as
+    // a placeholder in the settings UI (store.js's defaultViewportName()).
+    const viewportName = vp.name || `${os.hostname().toUpperCase()}_VIEWPORT`;
+    return { url: vp.url, username: vp.username, password: vp.password, viewportName };
+  }
   return store.getConfig();
 }
 
@@ -50,6 +79,11 @@ function onOpenExternal(_event, url) {
 
 // ── getLogger reference (set during registerIpcHandlers) ─────────────────────
 let _getLogger = null;
+
+/** Returns the current logger instance (or null before it is wired up). */
+function currentLogger() {
+  return _getLogger ? _getLogger() : null;
+}
 
 function onOpenLogFile(_event, logPath) {
   const resolvedPath = logPath || (_getLogger && _getLogger() && _getLogger().getLogPath());
@@ -113,6 +147,94 @@ async function onStartupSettingsGet() {
 
 function onStartupSettingsSet(_event, settings) {
   store.setStartupSettings(settings);
+}
+
+// ── Viewport config handlers ──────────────────────────────────────────────────
+
+async function onViewportConfigGet() {
+  // Renderer-safe: never ships the (decrypted or ciphertext) password.
+  return store.getViewportConfigRedacted();
+}
+
+function onViewportConfigSet(_event, settings) {
+  // Pure pass-through: the store owns passwordChanged handling and encryption.
+  store.setViewportConfig(settings);
+}
+
+/**
+ * Removes this viewer from Protect and resets the local device state:
+ * logs in with the stored admin credentials, finds the viewer row by the
+ * on-disk identity MAC, deletes it, then clears the identity dir and disables
+ * Viewport mode. The local reset runs even when no row was found (stale row
+ * already gone) — but NOT on a login/reach failure OR a rejected delete
+ * (non-2xx), so the identity survives for a retry while the device row may
+ * still exist on the console. Wiping the identity while the row remains would
+ * orphan it permanently: the next enable mints a new MAC, and the old row
+ * could never be found by MAC again.
+ *
+ * Secrets: the password is decrypted here in the MAIN process only, passed to
+ * admin-api.login, and never logged or included in the returned payload.
+ *
+ * @returns {Promise<{ok: boolean, removed?: boolean, message: string}>}
+ */
+async function onViewportRemove() {
+  const vp = store.getViewportConfig(); // MAIN-process only: decrypted password
+  if (!vp.url || !vp.username || !vp.password) {
+    return { ok: false, message: 'Viewport not configured' };
+  }
+  const adminApi = require('./viewport/adoption/admin-api');
+  const { httpJson } = require('./viewport/adoption/mint');
+  const { buildLoginRequest } = require('./viewport/adoption/token');
+  const { loadOrCreateIdentity } = require('./viewport/adoption/identity');
+  const { app } = require('electron');
+  const dataDir = path.join(app.getPath('userData'), 'viewport');
+  const dep = { httpJson, dataDir };
+  let removed = false;
+  try {
+    const { cookie } = await adminApi.login(vp.url, vp.username, vp.password, {
+      httpJson,
+      buildLoginRequest,
+      dataDir,
+    });
+    const identity = loadOrCreateIdentity(dataDir);
+    const viewer = await adminApi.findViewerByMac(vp.url, cookie, identity.mac, dep);
+    if (viewer) {
+      removed = await adminApi.deleteViewer(vp.url, cookie, viewer.id, dep);
+      if (!removed) {
+        // Delete rejected (non-2xx, e.g. 403/500): the row is still on the
+        // console, so treat it like a reach-failure — keep the identity and
+        // the enabled flag so a retry can find the same row by MAC.
+        return {
+          ok: false,
+          message:
+            'The console refused to delete the device. Nothing was changed locally — try again.',
+        };
+      }
+    }
+  } catch (e) {
+    // Identity intentionally NOT cleared: the device row may still exist on
+    // the console, and keeping the identity lets a retry find it by MAC.
+    return { ok: false, message: `Could not reach the console: ${e && e.message}` };
+  }
+  // Full local reset regardless of whether a row existed: the identity dir
+  // holds the device cert/key/MAC, so removing it makes the next enable mint
+  // a brand-new device instead of resurrecting the deleted one.
+  try {
+    require('node:fs').rmSync(dataDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort: a locked file must not block disabling viewport mode */
+  }
+  // passwordChanged:false → store.setViewportConfig retains the stored password
+  // ciphertext (store.js), so only `enabled` flips and the connection settings
+  // survive for a later re-enable.
+  store.setViewportConfig({ enabled: false, passwordChanged: false });
+  return {
+    ok: true,
+    removed,
+    message: removed
+      ? 'Viewport removed from Protect.'
+      : 'No matching device found; local identity reset.',
+  };
 }
 
 /**
@@ -212,6 +334,7 @@ function registerIpcHandlers(getLogger) {
   ipcMain.on('activeProfileSet', onActiveProfileSet);
   ipcMain.on('startupProfileSet', onStartupProfileSet);
   ipcMain.on('startupSettingsSet', onStartupSettingsSet);
+  ipcMain.on('viewportConfigSet', onViewportConfigSet);
   ipcMain.on('switchNextProfile', onSwitchNextProfile);
   ipcMain.on('launchProfile', onLaunchProfile);
   ipcMain.on(LOG_IPC_CHANNEL, makeWindowLogHandler(getLogger));
@@ -221,7 +344,9 @@ function registerIpcHandlers(getLogger) {
   ipcMain.handle('activeProfileGet', onActiveProfileGet);
   ipcMain.handle('startupProfileGet', onStartupProfileGet);
   ipcMain.handle('startupSettingsGet', onStartupSettingsGet);
+  ipcMain.handle('viewportConfigGet', onViewportConfigGet);
+  ipcMain.handle('viewportRemove', onViewportRemove);
   ipcMain.handle('displaysGet', onDisplaysGet);
 }
 
-module.exports = { registerIpcHandlers, registerF11Handler, makeWindowLogHandler };
+module.exports = { registerIpcHandlers, registerF11Handler, makeWindowLogHandler, currentLogger };

--- a/src/main/render-session.js
+++ b/src/main/render-session.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * @file render-session.js
+ * @description Tiny process-memory-only override for the EFFECTIVE render
+ * session (the URL + creds that ipc.js's `onConfigLoad` hands to preload.js
+ * for the unexpected-URL redirect and the auto-login form fill).
+ *
+ * Why this exists: when Viewport
+ * mode's adoption fails and window.js falls back to a configured profile, the
+ * render session must actually BECOME that profile — not silently keep
+ * authenticating as the still-"enabled" viewport connection. `onConfigLoad`
+ * has no other way to learn that a fallback happened (the viewport config in
+ * the store is untouched — only the in-window navigation state changed), so
+ * window.js sets this override at the moment it decides to fall back, and
+ * `onConfigLoad` checks it first, ahead of the viewport-connection gate.
+ *
+ * Deliberately NOT persisted (no store.set) — this is per-process runtime
+ * state only, cleared on every fresh `loadInitialPage` so a normal launch (no
+ * fallback) is never affected by a previous window's leftover override.
+ */
+
+/** @type {{url:string, username?:string, password?:string}|null} */
+let _override = null;
+
+/**
+ * Sets the render-session override. Pass a profile-shaped object (only
+ * url/username/password are retained — extra profile fields like `id`/`name`
+ * are intentionally dropped since `onConfigLoad`'s contract is `{url,
+ * username, password}`, same as the viewport-connection and profile paths).
+ * @param {{url:string, username?:string, password?:string}} config
+ */
+function setRenderCredentialOverride(config) {
+  _override = config
+    ? { url: config.url, username: config.username, password: config.password }
+    : null;
+}
+
+/**
+ * @returns {{url:string, username?:string, password?:string}|null} the
+ *   current override, or null when none is set (the common case).
+ */
+function getRenderCredentialOverride() {
+  return _override;
+}
+
+/** Clears the override. Safe to call when none is set. */
+function clear() {
+  _override = null;
+}
+
+module.exports = { setRenderCredentialOverride, getRenderCredentialOverride, clear };

--- a/src/main/secure.js
+++ b/src/main/secure.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * @file secure.js
+ * @description Secret-at-rest helper over Electron safeStorage.
+ *
+ * Stored format is self-describing via a prefix:
+ *   'enc:'   + base64(safeStorage.encryptString(plain))  — OS-encrypted
+ *   'plain:' + plain                                     — safeStorage unavailable
+ *                                                          (e.g. WSL2 without a keyring)
+ * A legacy bare string (no prefix) is treated as plaintext.
+ *
+ * All functions accept an optional `deps = { safeStorage, warn }` so unit tests
+ * inject a fake safeStorage — require('electron') only happens when no fake is
+ * given, keeping this module loadable in plain Node.
+ */
+
+const ENC_PREFIX = 'enc:';
+const PLAIN_PREFIX = 'plain:';
+
+function resolveDeps(deps) {
+  const warn = deps && deps.warn ? deps.warn : (msg) => console.warn(`[secure] ${msg}`);
+  if (deps && 'safeStorage' in deps) return { safeStorage: deps.safeStorage, warn };
+  // Lazy require: only touched at runtime inside Electron.
+  const { safeStorage } = require('electron');
+  return { safeStorage, warn };
+}
+
+/** @returns {boolean} whether OS-backed secret encryption is usable right now. */
+function isSecretEncryptionAvailable(deps) {
+  const { safeStorage } = resolveDeps(deps);
+  try {
+    return !!(safeStorage && safeStorage.isEncryptionAvailable());
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Encrypts a secret for storage. Empty input stays empty.
+ * @param {string} plain
+ * @returns {string} 'enc:'-prefixed ciphertext, or 'plain:'-prefixed fallback (warned).
+ */
+function encryptSecret(plain, deps) {
+  if (!plain) return '';
+  const d = resolveDeps(deps);
+  if (isSecretEncryptionAvailable(d)) {
+    return ENC_PREFIX + d.safeStorage.encryptString(plain).toString('base64');
+  }
+  d.warn('safeStorage encryption unavailable – storing secret with plain: marker');
+  return PLAIN_PREFIX + plain;
+}
+
+/**
+ * Decrypts a stored secret. Routes on the enc:/plain: prefix; a legacy bare
+ * string is returned as-is. A failed decrypt returns '' (and warns) so callers
+ * degrade to "no password" instead of crashing at launch.
+ * @param {string} stored
+ * @returns {string} the plaintext secret, or ''.
+ */
+function decryptSecret(stored, deps) {
+  if (!stored) return '';
+  if (stored.startsWith(PLAIN_PREFIX)) return stored.slice(PLAIN_PREFIX.length);
+  if (stored.startsWith(ENC_PREFIX)) {
+    const d = resolveDeps(deps);
+    try {
+      return d.safeStorage.decryptString(Buffer.from(stored.slice(ENC_PREFIX.length), 'base64'));
+    } catch (e) {
+      d.warn(`failed to decrypt stored secret: ${e.message}`);
+      return '';
+    }
+  }
+  return stored; // legacy bare value = plaintext
+}
+
+module.exports = {
+  encryptSecret,
+  decryptSecret,
+  isSecretEncryptionAvailable,
+  ENC_PREFIX,
+  PLAIN_PREFIX,
+};

--- a/src/main/store.js
+++ b/src/main/store.js
@@ -18,7 +18,9 @@
 
 const path = require('node:path');
 const fs = require('node:fs');
+const os = require('node:os');
 const Store = require('electron-store');
+const secure = require('./secure');
 
 // ── Portable detection ────────────────────────────────────────────────────────
 
@@ -155,6 +157,98 @@ function setStartupSettings(settings) {
   }
 }
 
+// ── Viewport mode ──────────────────────────────────────────────────────────────
+
+const VIEWPORT_DEFAULTS = Object.freeze({
+  enabled: false,
+  name: '',
+  url: '',
+  username: '',
+  password: '', // stored form: encryptSecret(...) output ('' = not set)
+  fallbackProfileId: null,
+});
+
+/** Default device name shown as a placeholder and used when name is empty. */
+function defaultViewportName() {
+  return `${os.hostname().toUpperCase()}_VIEWPORT`;
+}
+
+/**
+ * One-time migration of the legacy manual seed keys:
+ *   adoptUser → username, adoptPass → encrypted password, adopt → implied.
+ * Legacy adopt mode had no dedicated URL — it rode the active profile's URL,
+ * so `url` is backfilled from the active profile to preserve adopting behavior.
+ */
+function migrateViewportIfNeeded() {
+  const raw = store.get('viewport');
+  if (!raw) return;
+  if (!('adopt' in raw) && !('adoptUser' in raw) && !('adoptPass' in raw)) return;
+  const migrated = {
+    enabled: !!raw.enabled,
+    name: raw.name || '',
+    url: raw.url || (raw.adopt ? (getActiveProfile() || {}).url || '' : ''),
+    username: raw.username || raw.adoptUser || '',
+    password: raw.password || (raw.adoptPass ? secure.encryptSecret(raw.adoptPass) : ''),
+    fallbackProfileId: raw.fallbackProfileId ?? null,
+  };
+  store.set('viewport', migrated);
+}
+
+/** Stored (ciphertext) form, defaults merged. Internal. */
+function getStoredViewport() {
+  migrateViewportIfNeeded();
+  return { ...VIEWPORT_DEFAULTS, ...store.get('viewport', {}) };
+}
+
+/**
+ * MAIN-PROCESS ONLY: returns the viewport config with the password DECRYPTED
+ * for launch use (adoption + render auto-login). Never ship this to a renderer
+ * settings surface — use getViewportConfigRedacted() there.
+ * @returns {{ enabled:boolean, name:string, url:string, username:string,
+ *             password:string, fallbackProfileId:string|null }}
+ */
+function getViewportConfig() {
+  const stored = getStoredViewport();
+  return { ...stored, password: secure.decryptSecret(stored.password) };
+}
+
+/**
+ * Renderer-safe view of the viewport config: everything EXCEPT the password,
+ * plus hasPassword / encryptionAvailable / defaultName for the settings card.
+ */
+function getViewportConfigRedacted() {
+  const stored = getStoredViewport();
+  return {
+    enabled: stored.enabled,
+    name: stored.name,
+    url: stored.url,
+    username: stored.username,
+    fallbackProfileId: stored.fallbackProfileId,
+    hasPassword: !!stored.password,
+    encryptionAvailable: secure.isSecretEncryptionAvailable(),
+    defaultName: defaultViewportName(),
+  };
+}
+
+/**
+ * Merges and persists the viewport config. Password handling mirrors the
+ * profile form's "unchanged" pattern (config.html:1747): only when
+ * `settings.passwordChanged === true` is the incoming password (re-)encrypted;
+ * otherwise the stored ciphertext is retained and any incoming value ignored.
+ * @param {{ enabled?:boolean, name?:string, url?:string, username?:string,
+ *           password?:string, passwordChanged?:boolean,
+ *           fallbackProfileId?:string|null }} settings
+ * @returns {object} the merged stored-form (ciphertext) config
+ */
+function setViewportConfig(settings) {
+  const stored = getStoredViewport();
+  const { password, passwordChanged, ...rest } = settings || {};
+  const merged = { ...stored, ...rest };
+  merged.password = passwordChanged ? secure.encryptSecret(password || '') : stored.password;
+  store.set('viewport', merged);
+  return merged;
+}
+
 /** Returns the active profile object, or undefined. */
 function getActiveProfile() {
   const profiles = getProfiles();
@@ -240,6 +334,9 @@ module.exports = {
   setStartupProfileId,
   getStartupSettings,
   setStartupSettings,
+  getViewportConfig,
+  getViewportConfigRedacted,
+  setViewportConfig,
   getActiveProfile,
   getWindowBounds,
   saveWindowBounds,

--- a/src/main/viewport/adoption/README.md
+++ b/src/main/viewport/adoption/README.md
@@ -1,0 +1,7 @@
+# Viewport adoption
+
+In-process client that emulates a UniFi Protect Viewport device: connects
+mTLS-WebSocket to the NVR's device server (ds, :7442), adopts keyless with an
+admin-minted token, stays Online. Pure units: protocol/identity/token/backoff.
+Wire: connection (ws) + index (AdoptionClient). WS path, adopt sequence, and
+Viewport model string were verified against a live console.

--- a/src/main/viewport/adoption/admin-api.js
+++ b/src/main/viewport/adoption/admin-api.js
@@ -1,0 +1,92 @@
+'use strict';
+/**
+ * @file admin-api.js
+ * @description Pinned Protect admin-API viewer operations (find/rename/delete),
+ * reusing mint.js's httpJson (rejectUnauthorized:true + fingerprint pin — never
+ * relaxed). Endpoints are the ONLY place in the app that knows the viewer REST
+ * paths; verified against a live console.
+ */
+function origin(u) {
+  return new URL(u).origin;
+}
+function normalizeMac(mac) {
+  return String(mac || '')
+    .replace(/[^0-9a-fA-F]/g, '')
+    .toUpperCase();
+}
+
+// UniFi OS requires an X-CSRF-Token header on state-changing requests (PATCH /
+// DELETE / POST); a GET (bootstrap) does not. The token is carried inside the
+// JWT `TOKEN` session cookie (`csrfToken` claim), so rename/delete derive it
+// from the same cookie string they already receive — no extra round-trip, no
+// signature change. Returns null if absent/unparseable (caller omits the
+// header, preserving today's behavior on a non-UniFi-OS console). Verified
+// against a live console (rename → HTTP 200 with header).
+function csrfFromCookie(cookie) {
+  const m = /(?:^|;\s*)TOKEN=([^;]+)/.exec(cookie || '');
+  if (!m) return null;
+  const parts = m[1].split('.');
+  if (parts.length < 2) return null;
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')).csrfToken || null;
+  } catch {
+    return null;
+  }
+}
+function csrfHeader(cookie) {
+  const t = csrfFromCookie(cookie);
+  return t ? { 'x-csrf-token': t } : {};
+}
+
+async function login(baseUrl, username, password, { httpJson, buildLoginRequest, dataDir }) {
+  const res = await httpJson(buildLoginRequest(baseUrl, username, password), { dataDir });
+  if (res.status !== 200) throw new Error(`login HTTP ${res.status}`);
+  const cookie = (res.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  return { cookie };
+}
+
+async function findViewerByMac(baseUrl, cookie, mac, { httpJson, dataDir }) {
+  const res = await httpJson(
+    { url: origin(baseUrl) + '/proxy/protect/api/bootstrap', method: 'GET' },
+    { cookie, dataDir },
+  );
+  if (res.status !== 200) return null;
+  let viewers = [];
+  try {
+    viewers = JSON.parse(res.body).viewers || [];
+  } catch {
+    return null;
+  }
+  const want = normalizeMac(mac);
+  // Defensive (DELETE path): an empty/garbage MAC must never match a viewer
+  // whose own mac is empty or missing — that would delete an unrelated device.
+  if (!want) return null;
+  return viewers.find((v) => v && normalizeMac(v.mac) === want) || null;
+}
+
+async function renameViewer(baseUrl, cookie, id, name, { httpJson, dataDir }) {
+  const res = await httpJson(
+    {
+      url: origin(baseUrl) + '/proxy/protect/api/viewers/' + id,
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', ...csrfHeader(cookie) },
+      body: JSON.stringify({ name }),
+    },
+    { cookie, dataDir },
+  );
+  return res.status === 200;
+}
+
+async function deleteViewer(baseUrl, cookie, id, { httpJson, dataDir }) {
+  const res = await httpJson(
+    {
+      url: origin(baseUrl) + '/proxy/protect/api/viewers/' + id,
+      method: 'DELETE',
+      headers: { ...csrfHeader(cookie) },
+    },
+    { cookie, dataDir },
+  );
+  return res.status === 200 || res.status === 204;
+}
+
+module.exports = { normalizeMac, login, findViewerByMac, renameViewer, deleteViewer };

--- a/src/main/viewport/adoption/admin-api.js
+++ b/src/main/viewport/adoption/admin-api.js
@@ -89,4 +89,72 @@ async function deleteViewer(baseUrl, cookie, id, { httpJson, dataDir }) {
   return res.status === 200 || res.status === 204;
 }
 
-module.exports = { normalizeMac, login, findViewerByMac, renameViewer, deleteViewer };
+// ── Account setting: "Show Shared Multiviews" ────────────────────────────────
+// A viewport renders through a web session logged in as its admin account. If
+// an assigned Live View is a SHARED/public multiview (owned elsewhere / global),
+// Protect only shows it to an account that has "Show Shared Multiviews" enabled;
+// otherwise /protect/dashboard/<id> silently falls back to "All Cameras". That
+// toggle is a per-user server setting: `user.settings.web["liveview.includeGlobal"]`
+// (note the literal dotted key). Verified live: GET/PATCH `/proxy/protect/api/users/self`,
+// PATCH body `{settings:{web:{…,"liveview.includeGlobal":true}}}` + X-CSRF-Token → 200,
+// and it MERGES (other settings.web keys survive), so we read-modify-write.
+
+const INCLUDE_GLOBAL_KEY = 'liveview.includeGlobal';
+
+/** GETs the authenticated user (`users/self`); null on non-200 / parse error. */
+async function getSelf(baseUrl, cookie, { httpJson, dataDir }) {
+  const res = await httpJson(
+    { url: origin(baseUrl) + '/proxy/protect/api/users/self', method: 'GET' },
+    { cookie, dataDir },
+  );
+  if (res.status !== 200) return null;
+  try {
+    return JSON.parse(res.body);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensures the account's "Show Shared Multiviews" flag is on so shared/public
+ * multiviews render instead of falling back to All Cameras. Read-modify-write:
+ * PATCHes only when the flag isn't already true, preserving every other
+ * settings.web key. Best-effort — never throws to the caller.
+ * @returns {Promise<{ok:boolean, changed:boolean, reason?:string}>}
+ *   reason: 'read' (couldn't read self) | 'patch' (PATCH rejected) | undefined (ok)
+ */
+async function ensureIncludeGlobal(baseUrl, cookie, { httpJson, dataDir }) {
+  const self = await getSelf(baseUrl, cookie, { httpJson, dataDir });
+  if (!self) return { ok: false, changed: false, reason: 'read' };
+  const web = (self.settings && self.settings.web) || {};
+  if (web[INCLUDE_GLOBAL_KEY] === true) return { ok: true, changed: false };
+  // Preserve all existing settings (deep copy) and flip only the one flag.
+  // Guard a non-object settings / settings.web (a malformed console response) so
+  // this honours its "never throws" contract instead of crashing on a set.
+  const src = self.settings && typeof self.settings === 'object' ? self.settings : {};
+  const settings = JSON.parse(JSON.stringify(src));
+  if (!settings.web || typeof settings.web !== 'object') settings.web = {};
+  settings.web[INCLUDE_GLOBAL_KEY] = true;
+  const res = await httpJson(
+    {
+      url: origin(baseUrl) + '/proxy/protect/api/users/self',
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', ...csrfHeader(cookie) },
+      body: JSON.stringify({ settings }),
+    },
+    { cookie, dataDir },
+  );
+  return res.status === 200
+    ? { ok: true, changed: true }
+    : { ok: false, changed: true, reason: 'patch' };
+}
+
+module.exports = {
+  normalizeMac,
+  login,
+  findViewerByMac,
+  renameViewer,
+  deleteViewer,
+  getSelf,
+  ensureIncludeGlobal,
+};

--- a/src/main/viewport/adoption/backoff.js
+++ b/src/main/viewport/adoption/backoff.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/** Exponential reconnect backoff, capped. @returns {number} ms */
+function nextBackoffMs(attempt, { baseMs = 1000, maxMs = 10000 } = {}) {
+  return Math.min(maxMs, baseMs * 2 ** attempt);
+}
+
+module.exports = { nextBackoffMs };

--- a/src/main/viewport/adoption/connection.js
+++ b/src/main/viewport/adoption/connection.js
@@ -1,0 +1,360 @@
+'use strict';
+
+/**
+ * @file connection.js
+ * @description UCP viewer connection to the NVR device server (ds, :7442). No
+ * Electron. Opens a WebSocket (created by an injected, possibly-async
+ * `wsFactory` so the state machine is testable without a network), answers the
+ * on-connect request sequence, stays Online by holding the socket, and emits
+ * the interface events.
+ *
+ * SCOPE: connect, responder, online-on-open, configure->assignment,
+ * changeUserPassword->onPassword persist, stop/cleanup, AND resilience:
+ *
+ *  - Idle watchdog: the server pings to prove liveness; silence is a dead
+ *    link that `ws` won't otherwise surface. Every inbound frame/ping resets
+ *    a timer of idleTimeoutMs; on expiry the socket is terminated, which
+ *    drives the same unexpected-close reconnect path below.
+ *  - Backoff reconnect: an UNEXPECTED close (see _onClose) schedules
+ *    another open() after backoffFn(attempt), attempt incrementing per
+ *    try and resetting to 0 on the next successful open.
+ *  - Fatal classification: a ws upgrade rejected with HTTP 403 (fingerprint
+ *    mismatch) or 412 (bad x-mode) can never be fixed by retrying, so it is
+ *    surfaced as `error` with `.fatal = true` and reconnect is suppressed
+ *    (see _failFatal). Every other failure is treated as transient and
+ *    retried with backoff.
+ *  - Keyless-after-first-online: the one-time adopt token is consumed by
+ *    the first successful open (_onOpen nulls this._token); every
+ *    subsequent open() — including all reconnects — authenticates keyless,
+ *    via the pinned cert fingerprint alone.
+ *
+ * All timers go through the injected setTimeoutFn/clearTimeoutFn seams so
+ * tests can drive them without a real clock.
+ */
+
+const { EventEmitter } = require('node:events');
+const P = require('./protocol');
+const { certFingerprint256 } = require('./identity');
+const { nextBackoffMs } = require('./backoff');
+
+class AdoptionConnection extends EventEmitter {
+  constructor({
+    url,
+    identity,
+    token = null,
+    name,
+    wsFactory,
+    nowFn = () => Date.now(),
+    deviceInfoOpts = {},
+    onPassword = null,
+    idleTimeoutMs = 40000,
+    backoffFn = nextBackoffMs,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+    xType = 'UP Viewport',
+    xVersion = '1.4.33',
+    localIpFn = P.localIpForHost,
+  }) {
+    super();
+    this._url = url;
+    this._identity = identity;
+    this._token = token;
+    this._name = name;
+    this._wsFactory = wsFactory;
+    this._now = nowFn;
+    this._deviceInfoOpts = deviceInfoOpts;
+    this._onPassword = onPassword;
+    this._idleTimeoutMs = idleTimeoutMs;
+    this._backoffFn = backoffFn;
+    this._setTimeout = setTimeoutFn;
+    this._clearTimeout = clearTimeoutFn;
+    this._xType = xType;
+    this._xVersion = xVersion;
+    this._localIpFn = localIpFn;
+    this._ws = null;
+    this._queue = [];
+    this._online = false;
+    this._attempt = 0;
+    this._reconnectTimer = null;
+    this._idleTimer = null;
+    this._stopped = false;
+  }
+
+  /** Opens the ws via the injected factory and wires the on-connect responder. */
+  async open() {
+    if (this._stopped) return;
+    let ws;
+    try {
+      const fingerprint = certFingerprint256(this._identity);
+      // Best-effort: the real viewer LAN IP for the x-ip header (so Protect
+      // shows it instead of the ds-daemon-proxy's 127.0.0.1). Never lets a
+      // resolution failure (bad URL, probe error/timeout) break the
+      // connection — headers just come out unchanged, today's behavior.
+      let ip = null;
+      try {
+        ip = await this._localIpFn(new URL(this._url).hostname).catch(() => null);
+      } catch {
+        ip = null;
+      }
+      const headers = {
+        ...P.buildUpgradeHeaders({
+          mac: this._identity.mac,
+          ident: this._identity.ident,
+          fingerprint,
+          token: this._token,
+          ip,
+          xType: this._xType,
+          xVersion: this._xVersion,
+        }),
+        'x-adopted': 'true',
+      };
+      ws = await this._wsFactory(this._url, {
+        cert: this._identity.cert,
+        key: this._identity.key,
+        headers,
+      });
+    } catch (e) {
+      // wsFactory rejecting is a transient (network-level) failure, not a
+      // fatal classification (those only arrive via the ws upgrade
+      // response/error below) — retry with backoff, unless stop() already
+      // raced us here.
+      if (this._stopped) return;
+      this._emit('error', e);
+      this._scheduleReconnect();
+      return;
+    }
+    if (this._stopped) {
+      // stop() ran while the (possibly async) wsFactory was in flight —
+      // don't wire up a socket the caller no longer wants.
+      try {
+        ws.close();
+      } catch {
+        // ignore — socket already going away
+      }
+      return;
+    }
+    this._ws = ws;
+    this._queue = [];
+    ws.on('open', () => this._onOpen());
+    ws.on('message', (data) => this._onMessage(data));
+    ws.on('ping', () => this._resetIdle());
+    ws.on('close', () => this._onClose());
+    ws.on('unexpected-response', (_req, res) => this._onUnexpected(res));
+    ws.on('error', (e) => {
+      // 403/412 normally arrive via 'unexpected-response' above, not here —
+      // this branch is defensive in case some ws error path ever carries
+      // the status code directly on the error object instead.
+      if (e && this._isFatalCode(e.statusCode)) this._failFatal(e.statusCode);
+      else this._emit('error', e);
+    });
+  }
+
+  /** Closes the socket and stops the state machine. Safe pre-open / repeat calls. */
+  stop() {
+    this._stopped = true;
+    if (this._reconnectTimer) this._clearTimeout(this._reconnectTimer);
+    if (this._idleTimer) this._clearTimeout(this._idleTimer);
+    this._reconnectTimer = null;
+    this._idleTimer = null;
+    if (this._ws) {
+      // Strip listeners BEFORE close() so this intentional close never
+      // reaches _onClose — 'closed' (and the reconnect it schedules) only
+      // ever fires for an UNEXPECTED disconnect. _scheduleReconnect is also
+      // gated on _stopped as defense in depth, so a reconnect can never
+      // fire after stop() even if a timer callback is already in flight.
+      if (this._ws.removeAllListeners) this._ws.removeAllListeners();
+      try {
+        this._ws.close();
+      } catch {
+        // ignore — socket already going away
+      }
+    }
+    this._ws = null;
+    this._online = false;
+  }
+
+  // Online is CONNECTION-BASED: no handshake is required, just hold the
+  // socket open. The one-time adopt token is consumed on first connect:
+  // _token is nulled here, so every open() from here on — including every
+  // reconnect — builds keyless headers (buildUpgradeHeaders omits x-token
+  // when it's null), authenticating via the pinned cert fingerprint alone.
+  // A successful open also proves the link is healthy again, so the
+  // backoff attempt counter resets.
+  _onOpen() {
+    this._attempt = 0;
+    this._token = null;
+    this._online = true;
+    this._resetIdle();
+    this._emit('open');
+    this._emit('online');
+  }
+
+  _onMessage(data) {
+    if (!Buffer.isBuffer(data)) return;
+    // WS messages are atomic ([envelope][body] delivered whole) and always
+    // contain complete pairs, so each message is parsed independently — the
+    // queue is reset here, NOT carried across messages. Carrying a leftover
+    // (e.g. from a truncated/malformed frame within one message) into the
+    // next message's parse would silently mis-pair the next message's own
+    // envelope/body against the stale leftover, desyncing every echo after
+    // it until reconnect.
+    this._queue = [];
+    for (const f of P.parseFrames(data)) {
+      if (f.truncated) continue;
+      try {
+        this._queue.push(JSON.parse(f.payload.toString('utf8')));
+      } catch {
+        // skip non-JSON frame
+      }
+    }
+    const { pairs, remainder } = P.pairFrames(this._queue);
+    this._queue = remainder;
+    for (const { envelope, body } of pairs) this._handlePair(envelope, body);
+    // Any inbound frame proves the link is alive — reset the idle watchdog.
+    this._resetIdle();
+  }
+
+  _handlePair(envelope, body) {
+    if (!envelope || envelope.type !== 'request') return;
+    const action = envelope.action;
+    if (action === 'configure') this._emit('assignment', P.parseConfigure(body));
+    if (action === 'changeUserPassword' && body && body.passwordNew && this._onPassword) {
+      // See _emit()'s doc: a throwing consumer must not abort processing
+      // of the remaining pairs in this message.
+      try {
+        this._onPassword(body.passwordNew);
+      } catch {
+        // swallow — consumer's problem, not ours to propagate
+      }
+    }
+    // Every on-connect action gets acked, including enableUpdatesChannel —
+    // which MUST be acked but must NEVER open a second socket (confirmed
+    // backend behavior). replyBodyFor -> {} for anything but getInfo, and
+    // nothing in this method ever calls open()/wsFactory again.
+    const replyBody = P.replyBodyFor(action, {
+      identity: this._identity,
+      name: this._name,
+      deviceInfoOpts: this._deviceInfoOpts,
+    });
+    const out = P.buildResponseFrames(envelope, replyBody, this._now());
+    if (this._ws && this._ws.readyState === 1) this._ws.send(out);
+  }
+
+  // 'close' on the ws only ever reaches here for an UNEXPECTED disconnect
+  // (server hangup, network drop, idle-watchdog termination) — stop()
+  // strips all ws listeners before it closes the socket, so an intentional
+  // stop() never fires this handler and therefore never schedules a
+  // reconnect.
+  _onClose() {
+    this._online = false;
+    if (this._idleTimer) this._clearTimeout(this._idleTimer);
+    this._idleTimer = null;
+    this._emit('closed');
+    this._scheduleReconnect();
+  }
+
+  /** Resets the idle watchdog: fires _onIdle() after idleTimeoutMs of silence. */
+  _resetIdle() {
+    if (this._idleTimer) this._clearTimeout(this._idleTimer);
+    this._idleTimer = this._arm(() => this._onIdle(), this._idleTimeoutMs);
+  }
+
+  // The server pings on a live link; if idleTimeoutMs passes with no
+  // inbound frame/ping at all, the link is presumed dead (ws won't
+  // otherwise surface a half-open TCP connection). Terminate it — the
+  // resulting 'close' event drives the normal unexpected-close reconnect
+  // path in _onClose.
+  _onIdle() {
+    this._idleTimer = null;
+    if (this._ws) {
+      try {
+        if (this._ws.terminate) this._ws.terminate();
+        else this._ws.close();
+      } catch {
+        // ignore — socket already going away
+      }
+    }
+  }
+
+  _isFatalCode(code) {
+    return code === 403 || code === 412;
+  }
+
+  // A fingerprint mismatch (403) or bad x-mode (412) can never be fixed by
+  // retrying, so it's surfaced to the UI and reconnect is suppressed by
+  // latching _stopped — _scheduleReconnect() checks it and bails.
+  //
+  // IMPORTANT: real `ws` (8.18) does NOT clean up after itself here. Once a
+  // consumer listens for 'unexpected-response' (open() does), ws skips its
+  // own abortHandshake — so on a real 403/412 no 'close'/'error' event ever
+  // follows on its own and the TCP socket would leak forever, stuck in
+  // CONNECTING. This method must therefore terminate the socket itself
+  // (mirrors stop()/_onIdle's pattern) and drop the reference, exactly as
+  // if this were an intentional stop of a half-open connection.
+  _failFatal(code) {
+    const err = new Error(`fatal UCP upgrade rejected: HTTP ${code}`);
+    err.fatal = true;
+    this._stopped = true;
+    if (this._reconnectTimer) this._clearTimeout(this._reconnectTimer);
+    if (this._idleTimer) this._clearTimeout(this._idleTimer);
+    this._reconnectTimer = null;
+    this._idleTimer = null;
+    this._emit('error', err);
+    if (this._ws) {
+      try {
+        if (this._ws.terminate) this._ws.terminate();
+        else this._ws.close();
+      } catch {
+        // ignore — socket already going away
+      }
+      this._ws = null;
+    }
+  }
+
+  _onUnexpected(res) {
+    const code = res && res.statusCode;
+    if (this._isFatalCode(code)) this._failFatal(code);
+  }
+
+  // Schedules another open() after backoffFn(attempt), incrementing the
+  // attempt counter each call; _onOpen() resets it to 0 on success. Gated
+  // on _stopped as the single choke point that keeps a reconnect from ever
+  // firing after stop() (or after a fatal 403/412 latches _stopped).
+  _scheduleReconnect() {
+    if (this._stopped) return;
+    const delay = this._backoffFn(this._attempt++);
+    this._reconnectTimer = this._arm(() => {
+      this._reconnectTimer = null;
+      this.open();
+    }, delay);
+  }
+
+  // Arms a timer via the injected setTimeoutFn and, when it's the real
+  // setTimeout (i.e. the timer object supports it), unrefs it — the idle
+  // watchdog and reconnect timers are background housekeeping and must
+  // never be the reason a process (or a test run) stays alive/hangs.
+  // Fake timer doubles used in tests are plain objects with no .unref, so
+  // this is a no-op against them.
+  _arm(fn, ms) {
+    const t = this._setTimeout(fn, ms);
+    if (t && typeof t.unref === 'function') t.unref();
+    return t;
+  }
+
+  /**
+   * Emits an event guarded against a throwing listener. A consumer
+   * callback that throws must not abort processing of the remaining
+   * frames/pairs in the current message, nor unwind out of a ws event
+   * handler — so every emit in this class goes through here instead of
+   * calling this.emit() directly.
+   */
+  _emit(event, ...args) {
+    try {
+      this.emit(event, ...args);
+    } catch {
+      // swallow — a throwing consumer must not break the state machine
+    }
+  }
+}
+
+module.exports = { AdoptionConnection };

--- a/src/main/viewport/adoption/identity.js
+++ b/src/main/viewport/adoption/identity.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * @file identity.js
+ * @description The emulated device's stable identity: a self-signed TLS client
+ * cert (mTLS) + a locally-administered MAC. Generated once and persisted so the
+ * NVR sees the same device across restarts.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const selfsigned = require('selfsigned');
+
+/** Generates a stable locally-administered MAC as 12 uppercase hex chars. */
+function generateMac() {
+  const b = crypto.randomBytes(6);
+  b[0] = (b[0] & 0xfe) | 0x02; // locally-administered, unicast
+  return b.toString('hex').toUpperCase();
+}
+
+/**
+ * Loads the persisted device identity, generating + saving it on first use.
+ * @param {string} dir - directory to persist identity files in
+ * @returns {{ cert: string, key: string, mac: string, ident: string }}
+ */
+function loadOrCreateIdentity(dir) {
+  const p = (f) => path.join(dir, f);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  if (fs.existsSync(p('device.json'))) {
+    const meta = JSON.parse(fs.readFileSync(p('device.json'), 'utf8'));
+    return {
+      cert: fs.readFileSync(p('device.cert.pem'), 'utf8'),
+      key: fs.readFileSync(p('device.key.pem'), 'utf8'),
+      mac: meta.mac,
+      ident: meta.ident,
+    };
+  }
+  const mac = generateMac();
+  const ident = crypto.randomUUID();
+  const pems = selfsigned.generate([{ name: 'commonName', value: 'camera.ubnt.dev' }], {
+    keySize: 2048,
+    days: 3650,
+    algorithm: 'sha256',
+  });
+  fs.writeFileSync(p('device.cert.pem'), pems.cert);
+  fs.writeFileSync(p('device.key.pem'), pems.private, { mode: 0o600 });
+  fs.writeFileSync(p('device.json'), JSON.stringify({ mac, ident }));
+  return { cert: pems.cert, key: pems.private, mac, ident };
+}
+
+/** SHA-256 fingerprint of the device cert as uppercase colon-hex (x-fingerprint). */
+function certFingerprint256(identity) {
+  return new crypto.X509Certificate(identity.cert).fingerprint256;
+}
+
+module.exports = { loadOrCreateIdentity, generateMac, certFingerprint256 };

--- a/src/main/viewport/adoption/index.js
+++ b/src/main/viewport/adoption/index.js
@@ -1,0 +1,157 @@
+'use strict';
+
+/**
+ * @file index.js
+ * @description AdoptionClient — wires identity + (optional) token mint + UCP
+ * connection into one device-emulation lifecycle. IO is injectable so wiring is
+ * unit-tested. Token minting happens ONLY for the initial adopt (creds present);
+ * once the cert fingerprint is pinned server-side, reconnects are keyless — so
+ * the admin password is used at most once and never persisted.
+ *
+ * `conn.url` (an `https://<host>` admin/console URL — a saved profile's URL)
+ * serves TWO different endpoints that must NOT be conflated: `mintToken`
+ * dials the admin API on :443, but the UCP `ds` device daemon that actually
+ * accepts the connection lives on a different port, :7442. This is the ONE
+ * chokepoint that derives the ds WS URL (`protocol.dsWsUrl`) and hands it to
+ * the connection factory, while `mintToken` keeps receiving `conn.url`
+ * untouched.
+ */
+
+const { EventEmitter } = require('node:events');
+const { loadOrCreateIdentity } = require('./identity');
+const { dsWsUrl } = require('./protocol');
+
+class AdoptionClient extends EventEmitter {
+  constructor() {
+    super();
+    this._conn = null;
+    this._adopted = false;
+    this._renameDone = false;
+    this._cookie = null;
+    this._renameCtx = null;
+  }
+
+  /**
+   * @param {object} conn - { url, username?, password?, deviceName, dataDir,
+   *   deviceInfoOpts?, mintToken?, connectionFactory?, adminApi?, loadIdentity? }.
+   *   Keyless (no username/password) reconnects a pre-adopted, fingerprint-pinned
+   *   viewer without minting a token. `adminApi`/`loadIdentity` are test seams
+   *   overriding the real ./admin-api and ./identity modules.
+   */
+  async start(conn) {
+    try {
+      const loadIdentity = conn.loadIdentity || loadOrCreateIdentity;
+      const identity = loadIdentity(conn.dataDir);
+      let token = null;
+      if (conn.username && conn.password) {
+        const mint = conn.mintToken || require('./mint').mintToken;
+        const minted = await mint({ ...conn, identity });
+        token = minted.token;
+        // Login session cookie, reused for the best-effort post-online rename.
+        // Keyless reconnects never mint, so this stays null and rename skips.
+        this._cookie = minted.cookie || null;
+      }
+      this._renameCtx = {
+        url: conn.url, // admin https URL (:443) — NOT the derived :7442 ds URL
+        name: conn.deviceName,
+        dataDir: conn.dataDir,
+        mac: identity.mac,
+        adminApi: conn.adminApi || require('./admin-api'),
+      };
+      const factory = conn.connectionFactory || require('./mint').makeConnection;
+      this._conn = factory({
+        url: dsWsUrl(conn.url),
+        identity,
+        token,
+        name: conn.deviceName,
+        dataDir: conn.dataDir,
+        deviceInfoOpts: { isAdopted: true, ...(conn.deviceInfoOpts || {}) },
+      });
+      this._conn.on('online', () => {
+        this.emit('online', true);
+        if (!this._adopted) {
+          this._adopted = true;
+          // viewerId is not carried on the UCP wire; surface a bare adopted signal.
+          this.emit('adopted', { viewerId: null });
+        }
+        // Best-effort, fire-and-forget: _maybeRename catches its own errors;
+        // the trailing catch only guards emit('error') itself throwing when no
+        // listener is attached — a rename hiccup must never kill the process.
+        this._maybeRename().catch(() => {});
+      });
+      this._conn.on('closed', () => this.emit('online', false));
+      this._conn.on('assignment', (a) => this.emit('assignment', a));
+      this._conn.on('error', (e) =>
+        this.emit('error', {
+          message: e && e.message ? e.message : String(e),
+          fatal: !!(e && e.fatal),
+        }),
+      );
+      await this._conn.open();
+    } catch (e) {
+      const message = e && e.message ? e.message : String(e);
+      // Auth failures (bad admin password on a not-yet-adopted device) don't
+      // self-heal — retrying the same creds forever just leaves the app stuck
+      // on a dead login page. Mark them fatal so window.js's fatal → fallback
+      // (or surface-to-config, when no fallback is configured) path fires.
+      // mint.js's real error strings are `login HTTP <status>` and
+      // `manage-payload HTTP <status>`; only 401/403 are auth-specific — a
+      // network error (ECONNREFUSED, timeout) or a 5xx never matches and is
+      // emitted non-fatal. But at this mint stage no AdoptionConnection exists
+      // yet, so nothing here self-retries: recovery is only via window.js's
+      // fallback grace window or an app relaunch.
+      const authFailure = /\b(?:login|manage-payload) HTTP (?:401|403)\b/.test(message);
+      this.emit('error', { message, fatal: authFailure });
+    }
+  }
+
+  /**
+   * Best-effort: after the adopt goes online, rename the server-side viewer
+   * record to the configured deviceName. Only possible when this start() had
+   * creds (a mint login cookie exists) — keyless reconnects skip. The name is
+   * purely cosmetic, so ANY failure is emitted non-fatal and the next
+   * creds-bearing launch simply retries; nothing here may break adoption.
+   *
+   * Runs at most once per session: `_renameDone` latches after SUCCESS (viewer
+   * found AND its name already matched or the PATCH returned ok), so in-session
+   * reconnect `online` events stop re-fetching the large bootstrap. It does NOT
+   * latch when the viewer wasn't found yet (may appear on a later online), the
+   * PATCH returned falsy, or the admin API threw — those all retry on the next
+   * online. A fresh launch starts unlatched, preserving cross-launch self-heal.
+   */
+  async _maybeRename() {
+    const ctx = this._renameCtx;
+    if (this._renameDone || !ctx || !ctx.name || !this._cookie) return; // done, keyless reconnect (no cookie) or no name -> skip
+    try {
+      const dep = { httpJson: require('./mint').httpJson, dataDir: ctx.dataDir };
+      const viewer = await ctx.adminApi.findViewerByMac(ctx.url, this._cookie, ctx.mac, dep);
+      if (viewer) {
+        if (viewer.name === ctx.name) {
+          this._renameDone = true; // already correct — nothing left to do this session
+        } else {
+          const ok = await ctx.adminApi.renameViewer(
+            ctx.url,
+            this._cookie,
+            viewer.id,
+            ctx.name,
+            dep,
+          );
+          this.emit('renamed', { ok, name: ctx.name });
+          if (ok) this._renameDone = true; // falsy = transient failure -> retry next online
+        }
+      }
+    } catch (e) {
+      // non-fatal: name is cosmetic; next launch retries
+      this.emit('error', { message: `rename skipped: ${e && e.message}`, fatal: false });
+    }
+  }
+
+  stop() {
+    if (this._conn) {
+      this._conn.stop();
+      this._conn = null;
+    }
+  }
+}
+
+module.exports = { AdoptionClient, AdoptionConnection: require('./connection').AdoptionConnection };

--- a/src/main/viewport/adoption/index.js
+++ b/src/main/viewport/adoption/index.js
@@ -27,6 +27,7 @@ class AdoptionClient extends EventEmitter {
     this._conn = null;
     this._adopted = false;
     this._renameDone = false;
+    this._sharedViewsDone = false;
     this._cookie = null;
     this._renameCtx = null;
   }
@@ -78,6 +79,9 @@ class AdoptionClient extends EventEmitter {
         // the trailing catch only guards emit('error') itself throwing when no
         // listener is attached — a rename hiccup must never kill the process.
         this._maybeRename().catch(() => {});
+        // Likewise ensure the account can see shared/public multiviews, so an
+        // assigned shared Live View renders instead of falling back to All Cameras.
+        this._maybeEnsureSharedViews().catch(() => {});
       });
       this._conn.on('closed', () => this.emit('online', false));
       this._conn.on('assignment', (a) => this.emit('assignment', a));
@@ -143,6 +147,33 @@ class AdoptionClient extends EventEmitter {
     } catch (e) {
       // non-fatal: name is cosmetic; next launch retries
       this.emit('error', { message: `rename skipped: ${e && e.message}`, fatal: false });
+    }
+  }
+
+  /**
+   * Best-effort: after the adopt goes online, make sure the account's
+   * "Show Shared Multiviews" flag is on (`admin-api.ensureIncludeGlobal`), so an
+   * assigned SHARED/public multiview renders instead of Protect silently showing
+   * "All Cameras". Reuses the same mint login cookie as _maybeRename — keyless
+   * reconnects (no cookie) skip. Emits `sharedViews` with the outcome for the UI.
+   *
+   * Latches on SUCCESS (`_sharedViewsDone`) so in-session reconnects don't re-hit
+   * the API; a failure retries on the next online / launch. Purely a convenience
+   * for the render session — ANY failure is non-fatal and never touches adoption.
+   */
+  async _maybeEnsureSharedViews() {
+    const ctx = this._renameCtx;
+    if (this._sharedViewsDone || !ctx || !this._cookie) return; // done / keyless reconnect -> skip
+    // Test seams may inject an adminApi predating this method; treat it as a no-op.
+    if (typeof ctx.adminApi.ensureIncludeGlobal !== 'function') return;
+    try {
+      const dep = { httpJson: require('./mint').httpJson, dataDir: ctx.dataDir };
+      const res = await ctx.adminApi.ensureIncludeGlobal(ctx.url, this._cookie, dep);
+      this.emit('sharedViews', res || { ok: false, reason: 'read' });
+      if (res && res.ok) this._sharedViewsDone = true; // failure -> retry next online
+    } catch (e) {
+      // non-fatal: convenience only; next launch retries
+      this.emit('sharedViews', { ok: false, reason: 'exception' });
     }
   }
 

--- a/src/main/viewport/adoption/mint.js
+++ b/src/main/viewport/adoption/mint.js
@@ -1,0 +1,148 @@
+'use strict';
+
+/**
+ * @file mint.js
+ * @description Real IO wiring for AdoptionClient defaults: pinned HTTPS token
+ * minting (:443) and the pinned `ucp4` mTLS WebSocket (:7442). No Electron —
+ * `dataDir` is injected by the caller (window.js supplies
+ * `app.getPath('userData')/viewport`). Both TLS sites go through
+ * pinning.js's `buildTlsOptions` (`rejectUnauthorized:true` + fingerprint
+ * assert) — this file never sets `rejectUnauthorized:false` anywhere; that
+ * relaxed mode exists exactly once, inside pinning.js's own one-time TOFU
+ * probe.
+ *
+ * `connection.js`'s `open()` already assembles the full UCP header set
+ * (sec-websocket-protocol, x-ident, x-type, x-mode, x-fingerprint,
+ * x-version, x-adopted, and x-token when present) and calls
+ * `wsFactory(url, { cert, key, headers })` with it — so `makeConnection`'s
+ * `wsFactory` below MUST NOT rebuild those headers; it only merges the
+ * pinned TLS options on top of what it's given.
+ */
+
+const https = require('node:https');
+const { buildLoginRequest, managePayloadUrl, parseTokenResponse } = require('./token');
+const pinning = require('./pinning');
+
+const DEFAULT_PROBE_TIMEOUT_MS = 10000;
+
+/**
+ * Wraps `pinning.probeAndPin` with a caller-side deadline. `probeAndPin`
+ * itself has no internal timeout: if `tlsConnect` neither completes nor
+ * errors — a silent packet drop, a firewalled host — its promise never
+ * settles and the caller would
+ * hang forever with no user-visible feedback during adoption. This does not
+ * touch pinning.js; it only bounds how long mint.js is willing to wait on it.
+ */
+function probeAndPinWithTimeout({ host, port, dir, timeoutMs = DEFAULT_PROBE_TIMEOUT_MS }) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    // Deliberately NOT unref'd: unlike connection.js's idle/reconnect
+    // timers (background housekeeping on an already-open link), this timer
+    // guards foreground work the caller is actively awaiting (initial token
+    // mint / first connect) — it must fire and deliver its rejection even
+    // if it's the only thing outstanding, not let the process exit first.
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`TLS pin probe for ${host}:${port} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    pinning.probeAndPin({ host, port, dir }).then(
+      (pin) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(pin);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/**
+ * Pinned HTTPS JSON request. Probes+pins the target host (or reuses an
+ * already-pinned host) and issues the request with
+ * `pinning.buildTlsOptions(pin)` — never `rejectUnauthorized:false`.
+ */
+async function httpJson(reqDesc, { cookie, dataDir } = {}) {
+  const u = new URL(reqDesc.url);
+  const host = u.hostname;
+  const port = Number(u.port) || 443;
+  const pin = await probeAndPinWithTimeout({ host, port, dir: dataDir });
+  const tlsOpts = pinning.buildTlsOptions(pin);
+  return new Promise((resolve, reject) => {
+    const headers = { ...reqDesc.headers };
+    if (cookie) headers.cookie = cookie;
+    const req = https.request(
+      {
+        hostname: host,
+        port,
+        path: u.pathname + u.search,
+        method: reqDesc.method || 'GET',
+        headers,
+        ...tlsOpts,
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (c) => (body += c));
+        res.on('end', () =>
+          resolve({ status: res.statusCode, setCookie: res.headers['set-cookie'], body }),
+        );
+      },
+    );
+    req.on('error', reject);
+    if (reqDesc.body) req.write(reqDesc.body);
+    req.end();
+  });
+}
+
+/**
+ * POST login → GET manage-payload → `{ token, cookie }` (pinned HTTPS; used
+ * only for initial adopt). The login session cookie is surfaced alongside the
+ * token so the adopt flow can reuse the already-authenticated session (e.g.
+ * for a post-adopt rename) without a second login.
+ */
+async function mintToken({ url, username, password, dataDir }) {
+  const login = await httpJson(buildLoginRequest(url, username, password), { dataDir });
+  if (login.status !== 200) throw new Error(`login HTTP ${login.status}`);
+  const cookie = (login.setCookie || []).map((c) => c.split(';')[0]).join('; ');
+  const mp = await httpJson({ url: managePayloadUrl(url), method: 'GET' }, { cookie, dataDir });
+  if (mp.status !== 200) throw new Error(`manage-payload HTTP ${mp.status}`);
+  return { token: parseTokenResponse(JSON.parse(mp.body)), cookie };
+}
+
+/**
+ * Builds a real AdoptionConnection whose async wsFactory pins TLS onto the
+ * `{cert, key, headers}` that `connection.js`'s `open()` already assembles
+ * (see file header — the full UCP header set is built there, NOT here). The
+ * ws URL is the derived ds URL (`protocol.dsWsUrl`, :7442 — see index.js),
+ * so this pins the `ds` daemon's OWN cert, independently of `mintToken`'s
+ * :443 probe: pinning.js keys pins by `host:port`, so :443 and :7442 are
+ * separate entries even though `dataDir` (and therefore the pins file) is
+ * shared between them. A repeat connect to the SAME host:port still reuses
+ * its cached pin (no re-probe) — see pinning.js's `probeAndPin`.
+ */
+function makeConnection(opts) {
+  const { AdoptionConnection } = require('./connection');
+  const { dataDir } = opts;
+  const wsFactory = async (url, { cert, key, headers }) => {
+    // Required lazily (not at module top-level) so tests can swap the `ws`
+    // module out from under this factory without a real network probe.
+    const WebSocket = require('ws');
+    const u = new URL(url);
+    const host = u.hostname;
+    const port = Number(u.port) || 7442;
+    const pin = await probeAndPinWithTimeout({ host, port, dir: dataDir });
+    const tlsOpts = pinning.buildTlsOptions(pin);
+    // Empty protocols arg: subprotocol is asserted via the header (ws would
+    // abort if it required the server to echo it). Verified against a live console.
+    return new WebSocket(url, [], { cert, key, headers, ...tlsOpts });
+  };
+  return new AdoptionConnection({ ...opts, wsFactory });
+}
+
+module.exports = { mintToken, makeConnection, httpJson, probeAndPinWithTimeout };

--- a/src/main/viewport/adoption/pinning.js
+++ b/src/main/viewport/adoption/pinning.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * @file pinning.js
+ * @description TOFU (trust-on-first-use) pinning of the NVR TLS cert. No Electron.
+ * Captures the console cert on first connect (the trust decision happens in that
+ * LAN first-use window), persists it per `host:port`, and verifies via a leaf-as-CA
+ * pin plus a fingerprint256 checkServerIdentity — because with
+ * rejectUnauthorized:false Node never calls checkServerIdentity, so we keep
+ * rejectUnauthorized:true. Pins are keyed by `host:port`, NOT host alone: on a
+ * UDM the admin API (:443, behind the UniFi OS reverse proxy) and the `ds`
+ * device daemon (:7442) present DIFFERENT leaf certs, so each endpoint must be
+ * probed and pinned independently — sharing one pin across ports would make the
+ * ds connection's checkServerIdentity fail against the :443 web-proxy cert.
+ * A repeat probe of the SAME host:port still reuses
+ * its cached pin. Fails loudly on change.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const tls = require('node:tls');
+
+function pinsFile(dir) {
+  return path.join(dir, 'nvr-pins.json');
+}
+
+/** The pin-map key for one endpoint: distinct ports on the same host pin separately. */
+function pinKey(host, port) {
+  return `${host}:${port}`;
+}
+
+/** Load the "host:port"->pin map (or {} if none). */
+function loadPins(dir) {
+  try {
+    return JSON.parse(fs.readFileSync(pinsFile(dir), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/** Persist a pin for one host:port endpoint (0700 dir / 0600 file). */
+function savePin(dir, host, port, pin) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const pins = loadPins(dir);
+  pins[pinKey(host, port)] = pin;
+  fs.writeFileSync(pinsFile(dir), JSON.stringify(pins), { mode: 0o600 });
+}
+
+/** TLS options that trust ONLY the pinned leaf and assert its fingerprint. */
+function buildTlsOptions(pin) {
+  return {
+    ca: pin.certPem,
+    rejectUnauthorized: true,
+    checkServerIdentity: (host, cert) =>
+      cert && cert.fingerprint256 === pin.fp256
+        ? undefined
+        : new Error(
+            `NVR cert fingerprint changed for ${host} (expected ${pin.fp256}) — refusing to connect`,
+          ),
+  };
+}
+
+function pemFromRaw(raw) {
+  const b64 = raw
+    .toString('base64')
+    .match(/.{1,64}/g)
+    .join('\n');
+  return `-----BEGIN CERTIFICATE-----\n${b64}\n-----END CERTIFICATE-----\n`;
+}
+
+/**
+ * Return the pinned {fp256,certPem} for one host:port endpoint,
+ * capturing+persisting on first use of THAT endpoint.
+ *
+ * SECURITY NOTE: the capture connection below is the ONLY place in this module
+ * (and the only sanctioned place anywhere in the adoption flow) where
+ * `rejectUnauthorized:false` is used. It is a one-time trust-on-first-use probe
+ * that opens a brief LAN-MITM window during initial adoption of a console — an
+ * attacker on the local network at that exact moment could hand us a forged
+ * leaf. Once captured, the fingerprint is persisted and every subsequent
+ * connection to THIS host:port MUST go through buildTlsOptions(), which pins
+ * the leaf as CA + asserts fingerprint256 with rejectUnauthorized:true. The
+ * admin API (:443) and the ds daemon (:7442) are each probed and pinned on
+ * their own — see the file header. Never reuse this relaxed path for
+ * steady-state traffic.
+ */
+async function probeAndPin({ host, port = 443, dir, tlsConnect = tls.connect }) {
+  const existing = loadPins(dir)[pinKey(host, port)];
+  if (existing) return existing;
+  const pin = await new Promise((resolve, reject) => {
+    const socket = tlsConnect({ host, port, servername: host, rejectUnauthorized: false }, () => {
+      const cert = socket.getPeerCertificate(true);
+      if (!cert || !cert.fingerprint256 || !cert.raw) {
+        socket.destroy();
+        return reject(new Error('no peer certificate to pin'));
+      }
+      const out = { fp256: cert.fingerprint256, certPem: pemFromRaw(cert.raw) };
+      socket.destroy();
+      resolve(out);
+    });
+    socket.on('error', reject);
+  });
+  savePin(dir, host, port, pin);
+  return pin;
+}
+
+module.exports = { loadPins, savePin, buildTlsOptions, probeAndPin };

--- a/src/main/viewport/adoption/protocol.js
+++ b/src/main/viewport/adoption/protocol.js
@@ -1,0 +1,203 @@
+'use strict';
+
+/**
+ * @file protocol.js
+ * @description Pure UCP viewer wire logic. No IO, no Electron. Frame codec
+ * `[1B ver=01][1B type=01][6B BE len][JSON]`, positional envelope+body pairing,
+ * response/deviceInfo/configure builders, and upgrade headers. Unit-tested with
+ * fixtures captured from a live console.
+ *
+ * Also carries `dsWsUrl` — a small pure URL derivation (host in, ds WS URL
+ * out) needed because the admin API (:443) and the `ds` device daemon
+ * (:7442) are different services at different ports on the same NVR; see
+ * its own doc comment below.
+ */
+
+/** Encode one UCP frame: [ver][type][6B BE len][utf8 JSON]. */
+function encodeFrame(obj, ver = 1, type = 1) {
+  const body = Buffer.from(JSON.stringify(obj), 'utf8');
+  const head = Buffer.alloc(8);
+  head[0] = ver;
+  head[1] = type;
+  head.writeUIntBE(body.length, 2, 6);
+  return Buffer.concat([head, body]);
+}
+
+/** Parse all complete frames in a buffer; a short tail is flagged truncated. */
+function parseFrames(buf) {
+  const out = [];
+  let off = 0;
+  while (off + 8 <= buf.length) {
+    const ver = buf[off];
+    const type = buf[off + 1];
+    const len = buf.readUIntBE(off + 2, 6);
+    const end = off + 8 + len;
+    if (end > buf.length) {
+      out.push({ ver, type, len, truncated: true, avail: buf.length - off - 8 });
+      break;
+    }
+    out.push({ ver, type, len, payload: buf.subarray(off + 8, end) });
+    off = end;
+  }
+  return out;
+}
+
+/**
+ * Pair decoded frame objects positionally: [0]=envelope, [1]=body, [2]=envelope…
+ * A trailing odd object is returned in `remainder` so a persistent frame queue
+ * can carry it to the next message. Never content-sniffs; never assumes one pair.
+ */
+function pairFrames(objs) {
+  const pairs = [];
+  let i = 0;
+  while (i + 1 <= objs.length - 1) {
+    pairs.push({ envelope: objs[i], body: objs[i + 1] });
+    i += 2;
+  }
+  return { pairs, remainder: objs.slice(i) };
+}
+
+/** Two-frame response: [envelope{type:'response',action,id,timestamp}][body]. */
+function buildResponseFrames(envelope, body, nowMs) {
+  const respEnv = { timestamp: nowMs, type: 'response', action: envelope.action, id: envelope.id };
+  return Buffer.concat([encodeFrame(respEnv), encodeFrame(body || {})]);
+}
+
+/** Complete, truthful getInfo body derived from identity + opts. */
+function buildDeviceInfo(identity, name, opts = {}) {
+  return {
+    mac: identity.mac,
+    name,
+    model: opts.model || 'UP Viewport',
+    modelKey: 'viewer',
+    firmwareVersion: opts.firmwareVersion || '1.4.33',
+    hardwareRevision: opts.hardwareRevision || '1',
+    guid: identity.ident,
+    ip: opts.ip || '127.0.0.1',
+    uptime: typeof opts.uptime === 'number' ? opts.uptime : 0,
+    isProvisioned: true,
+    isAdopted: opts.isAdopted === true,
+    features: opts.features || {},
+  };
+}
+
+/** The native assignment: liveview is an OBJECT; absent -> null (unassign). */
+function parseConfigure(body) {
+  const lv = body && body.liveview;
+  if (!lv || typeof lv !== 'object') return null;
+  const liveviewId = lv.id || lv._id || null;
+  if (!liveviewId) return null;
+  return { liveviewId, liveview: lv };
+}
+
+/** Reply body for an on-connect request action. getInfo -> info; else -> {} ack. */
+function replyBodyFor(action, ctx) {
+  if (action === 'getInfo')
+    return buildDeviceInfo(ctx.identity, ctx.name, ctx.deviceInfoOpts || {});
+  return {};
+}
+
+/** WebSocket upgrade headers for verifyUcpClientHttp (subprotocol set via header). */
+function buildUpgradeHeaders({
+  mac,
+  ident,
+  fingerprint,
+  token,
+  ip,
+  xType = 'UP Viewport',
+  xVersion = '1.4.33',
+}) {
+  const h = {
+    'sec-websocket-protocol': 'ucp4',
+    'x-ident': mac,
+    'x-type': xType,
+    'x-mode': '0',
+    'x-fingerprint': fingerprint,
+    'x-version': xVersion,
+  };
+  if (ident) h['x-guid'] = ident;
+  if (token) h['x-token'] = token;
+  if (typeof ip === 'string' && ip) h['x-ip'] = ip;
+  return h;
+}
+
+/**
+ * Resolves the OS's SOURCE IP for reaching `host` — a UDP "routing probe".
+ * Connecting a udp4 socket to an arbitrary port on `host` sends NO packets
+ * (UDP connect() only sets the kernel's default peer for routing purposes);
+ * it just makes the kernel pick a route, and `socket.address().address` is
+ * the local interface IP that route would use. This is how the app learns
+ * its own LAN-facing IP without hardcoding an interface name, for the `x-ip`
+ * upgrade header (see buildUpgradeHeaders) so Protect shows the viewer's
+ * real IP instead of the ds-daemon-proxy's 127.0.0.1.
+ *
+ * Pure Node (`dgram`), NOT Electron — `dgramFactory` is injectable so tests
+ * can drive a fake socket without touching the real network. Never rejects:
+ * any failure (bad host, closed socket, timeout) resolves `null`, and the
+ * caller (connection.js's open()) treats that as "omit x-ip", the safe
+ * pre-existing fallback.
+ */
+function localIpForHost(host, { timeoutMs = 500, dgramFactory } = {}) {
+  const createSocket = dgramFactory || require('node:dgram').createSocket;
+  return new Promise((resolve) => {
+    let settled = false;
+    let socket;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (socket) {
+        try {
+          socket.close();
+        } catch {
+          // ignore — socket already going away
+        }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    if (timer.unref) timer.unref();
+    try {
+      socket = createSocket('udp4');
+      socket.on('error', () => finish(null));
+      socket.connect(9, host, () => {
+        try {
+          finish(socket.address().address);
+        } catch {
+          finish(null);
+        }
+      });
+    } catch {
+      finish(null);
+    }
+  });
+}
+
+/**
+ * Derives the `ds` daemon's WebSocket URL from the NVR's https base URL
+ * (e.g. a saved profile's `https://<host>` — also used as-is for the admin
+ * API and for native render). The admin/mint API lives on :443 behind the
+ * UniFi OS reverse proxy; the UCP `ds` device daemon that actually accepts
+ * viewer adoption lives on a SEPARATE port, :7442, on the SAME host. Only
+ * the hostname is carried over — any port/path/query on the input is
+ * discarded, never merged in, so a profile URL that happens to include a
+ * non-standard https port (or a path, e.g. `/protect`) still yields plain
+ * `wss://<hostname>:7442/viewer/1.0/ws`.
+ */
+function dsWsUrl(baseUrl, { port = 7442, path = '/viewer/1.0/ws' } = {}) {
+  const { hostname } = new URL(baseUrl);
+  return `wss://${hostname}:${port}${path}`;
+}
+
+module.exports = {
+  encodeFrame,
+  parseFrames,
+  pairFrames,
+  buildResponseFrames,
+  buildDeviceInfo,
+  parseConfigure,
+  replyBodyFor,
+  buildUpgradeHeaders,
+  localIpForHost,
+  dsWsUrl,
+};

--- a/src/main/viewport/adoption/token.js
+++ b/src/main/viewport/adoption/token.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * @file token.js
+ * @description Pure request shaping + parsing for minting the adoption token.
+ * Flow (wired in index.js): POST /api/auth/login (admin creds) → session cookie
+ * → GET /proxy/protect/api/cameras/manage-payload → mgmt.token (60-min TTL).
+ */
+
+/** Builds the UniFi OS login request descriptor. */
+function buildLoginRequest(baseUrl, username, password) {
+  const origin = new URL(baseUrl).origin;
+  return {
+    url: `${origin}/api/auth/login`,
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username, password, rememberMe: false }),
+  };
+}
+
+/** The Protect manage-payload endpoint that returns the adoption token. */
+function managePayloadUrl(baseUrl) {
+  return `${new URL(baseUrl).origin}/proxy/protect/api/cameras/manage-payload`;
+}
+
+/** Extracts the adoption token from the manage-payload response. */
+function parseTokenResponse(json) {
+  const token = json && json.mgmt && json.mgmt.token;
+  if (!token) throw new Error('manage-payload response missing mgmt.token');
+  return token;
+}
+
+module.exports = { buildLoginRequest, managePayloadUrl, parseTokenResponse };

--- a/src/main/viewport/assignment.js
+++ b/src/main/viewport/assignment.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * @file assignment.js
+ * @description Pure helpers for resolving a Viewport's assigned liveview from a
+ * Protect bootstrap payload and building the render URL. No Electron/IO here.
+ */
+
+/** Finds the viewer object with the given name in a bootstrap payload. */
+function findViewer(bootstrap, name) {
+  const viewers = (bootstrap && bootstrap.viewers) || [];
+  return viewers.find((v) => v && v.name === name) || null;
+}
+
+/**
+ * Returns the viewer's assigned liveview id, or null if none/absent.
+ * The bootstrap JSON exposes the assignment as `liveview`; `liveviewId` is
+ * Protect's Postgres column name — accept both to be safe.
+ */
+function selectLiveviewId(bootstrap, name) {
+  const viewer = findViewer(bootstrap, name);
+  if (!viewer) return null;
+  return viewer.liveview || viewer.liveviewId || null;
+}
+
+/** Builds the Protect dashboard URL for a liveview id, or null if no id. */
+function liveviewUrl(baseUrl, liveviewId) {
+  if (!liveviewId) return null;
+  const origin = new URL(baseUrl).origin;
+  return `${origin}/protect/dashboard/${liveviewId}`;
+}
+
+/** Liveview URL when assigned, otherwise the profile's base URL. */
+function assignmentTargetUrl(baseUrl, liveviewId) {
+  return liveviewUrl(baseUrl, liveviewId) || baseUrl;
+}
+
+module.exports = { findViewer, selectLiveviewId, liveviewUrl, assignmentTargetUrl };

--- a/src/main/viewport/bridge.js
+++ b/src/main/viewport/bridge.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * @file bridge.js
+ * @description Polls Protect's bootstrap for this Viewport's assigned liveview
+ * and emits change events. IO is injected (`fetchBootstrap`) so it is testable
+ * without Electron. Used as the fallback when no dedicated device connection
+ * (adoption) is configured.
+ */
+
+const { EventEmitter } = require('node:events');
+const { selectLiveviewId } = require('./assignment');
+
+const DEFAULT_INTERVAL_MS = 5000;
+
+class ViewportBridge extends EventEmitter {
+  /**
+   * @param {object} opts
+   * @param {string} opts.name - the viewer device name to track
+   * @param {() => Promise<object>} opts.fetchBootstrap - resolves the bootstrap JSON
+   * @param {number} [opts.intervalMs]
+   * @param {typeof setInterval} [opts.setInterval] - injectable for tests
+   * @param {typeof clearInterval} [opts.clearInterval] - injectable for tests
+   */
+  constructor({
+    name,
+    fetchBootstrap,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    setInterval: si = setInterval,
+    clearInterval: ci = clearInterval,
+  }) {
+    super();
+    this._name = name;
+    this._fetchBootstrap = fetchBootstrap;
+    this._intervalMs = intervalMs;
+    this._setInterval = si;
+    this._clearInterval = ci;
+    this._timer = null;
+    this._lastLiveviewId = undefined; // undefined = nothing emitted yet
+  }
+
+  start() {
+    if (this._timer) return;
+    this._poll();
+    this._timer = this._setInterval(() => this._poll(), this._intervalMs);
+  }
+
+  stop() {
+    if (this._timer) {
+      this._clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  async _poll() {
+    try {
+      const bootstrap = await this._fetchBootstrap();
+      const liveviewId = selectLiveviewId(bootstrap, this._name);
+      this.emit('status', { ok: true, error: null });
+      if (liveviewId !== this._lastLiveviewId) {
+        this._lastLiveviewId = liveviewId;
+        this.emit('assignment', liveviewId);
+      }
+    } catch (err) {
+      this.emit('status', { ok: false, error: err && err.message ? err.message : String(err) });
+    }
+  }
+}
+
+module.exports = { ViewportBridge };

--- a/src/main/viewport/native.js
+++ b/src/main/viewport/native.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * @file native.js
+ * @description Pure bridge from an AdoptionClient's `assignment` events to window
+ * navigation. No Electron — `navigate(url)` is injected so window.js owns the
+ * BrowserWindow. Dedupes by last target (same-liveview re-shares are no-ops).
+ */
+
+const { assignmentTargetUrl } = require('./assignment');
+
+/**
+ * @param {object} p
+ * @param {import('events').EventEmitter} p.client - an AdoptionClient
+ * @param {string} p.baseUrl - the profile/NVR base URL
+ * @param {(url:string)=>void} p.navigate - performs the window navigation
+ * @param {(msg:string)=>void} [p.log]
+ * @returns {{ stop: () => void }}
+ */
+function startNativeViewport({ client, baseUrl, navigate, log = () => {} }) {
+  let currentTarget = null;
+
+  const onOnline = (v) => log(v ? 'device online' : 'device offline');
+  const onAssignment = (a) => {
+    const liveviewId = a && a.liveviewId ? a.liveviewId : null;
+    const target = assignmentTargetUrl(baseUrl, liveviewId);
+    if (target === currentTarget) {
+      log(`assignment ${liveviewId} (same target, skip)`);
+      return;
+    }
+    currentTarget = target;
+    log(`assignment ${liveviewId} → ${target}`);
+    navigate(target);
+  };
+  const onError = (e) => log(`adoption error: ${e && e.message}`);
+
+  client.on('online', onOnline);
+  client.on('assignment', onAssignment);
+  client.on('error', onError);
+
+  return {
+    stop() {
+      // Explicitly unsubscribe rather than relying solely on the client
+      // ceasing emission after stop() — cheap leak-safety if `client` is
+      // reused/restarted or outlives this bridge.
+      client.off('online', onOnline);
+      client.off('assignment', onAssignment);
+      client.off('error', onError);
+      client.stop();
+    },
+  };
+}
+
+module.exports = { startNativeViewport };

--- a/src/main/viewport/shared-views-status.js
+++ b/src/main/viewport/shared-views-status.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * @file shared-views-status.js
+ * @description In-memory holder for this launch's "Show Shared Multiviews"
+ * auto-enable outcome. window.js sets it from the AdoptionClient's `sharedViews`
+ * event; ipc.js reads it for the `viewportSharedViewsStatus` IPC so config.html
+ * can warn only when the auto-enable actually ran and failed. A standalone
+ * module (rather than living in window.js) avoids a window.js ↔ ipc.js require
+ * cycle. State resets on process start; never holds secrets.
+ */
+
+let _status = { ran: false, ok: false, reason: null };
+
+module.exports = {
+  /** @param {{ok?:boolean, reason?:string}} s */
+  set(s) {
+    _status = { ran: true, ok: !!(s && s.ok), reason: (s && s.reason) || null };
+  },
+  /** @returns {{ran:boolean, ok:boolean, reason:string|null}} */
+  get() {
+    return { ..._status };
+  },
+};

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -17,6 +17,7 @@ const { ViewportBridge } = require('./viewport/bridge');
 const { assignmentTargetUrl } = require('./viewport/assignment');
 const { AdoptionClient } = require('./viewport/adoption');
 const { startNativeViewport } = require('./viewport/native');
+const sharedViewsStatus = require('./viewport/shared-views-status');
 
 /** Diagnostic log helper for viewport mode → routes to upv.log. */
 function vlog(msg) {
@@ -191,6 +192,20 @@ function startViewportBridge(win, connection) {
         .catch((e) => vlog(`navigation failed: ${e.message}`));
     };
     const handle = startNativeViewport({ client, baseUrl: connection.url, navigate, log: vlog });
+
+    // Best-effort "Show Shared Multiviews" enforcement result (from the
+    // AdoptionClient's post-online admin-api call). Recorded so config.html can
+    // warn if it couldn't run; logged for diagnostics. Never affects navigation.
+    client.on('sharedViews', (r) => {
+      sharedViewsStatus.set(r);
+      vlog(
+        r && r.ok
+          ? r.changed
+            ? 'shared multiviews: enabled for the account (was off)'
+            : 'shared multiviews: already enabled'
+          : `shared multiviews: could not verify (${(r && r.reason) || 'unknown'})`,
+      );
+    });
 
     // ── Fallback plumbing: fatal error or no online within the grace
     // window → load the configured fallback profile instead. ──────────────────

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -5,11 +5,24 @@
  * @description Main browser window creation and lifecycle management.
  */
 
-const { BrowserWindow, screen } = require('electron');
+const { BrowserWindow, screen, app } = require('electron');
 const path = require('node:path');
+const os = require('node:os');
 const store = require('./store');
+const renderSession = require('./render-session');
 const { createTray } = require('./tray');
-const { registerF11Handler } = require('./ipc');
+const { registerF11Handler, currentLogger } = require('./ipc');
+const { LOG_SOURCE_APP } = require('./logger');
+const { ViewportBridge } = require('./viewport/bridge');
+const { assignmentTargetUrl } = require('./viewport/assignment');
+const { AdoptionClient } = require('./viewport/adoption');
+const { startNativeViewport } = require('./viewport/native');
+
+/** Diagnostic log helper for viewport mode → routes to upv.log. */
+function vlog(msg) {
+  const logger = currentLogger();
+  if (logger) logger.log(LOG_SOURCE_APP, `[viewport] ${msg}`);
+}
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -18,6 +31,10 @@ const USER_AGENT =
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 760;
 const ICON_PATH = path.join(__dirname, '../img/128.png');
+
+/** Grace window: if a fallback profile is configured and the viewport never
+ * comes online within this window, load the fallback instead. */
+const FALLBACK_GRACE_MS = 60_000;
 
 // ── Display helpers ───────────────────────────────────────────────────────────
 
@@ -45,10 +62,241 @@ function getSortedDisplays() {
   });
 }
 
+// ── Viewport mode ─────────────────────────────────────────────────────────────
+
+/**
+ * Builds a bootstrap fetcher that runs `fetch` inside the logged-in Protect page
+ * (via executeJavaScript), so it uses the page's real authenticated session.
+ * @param {BrowserWindow} win
+ * @param {string} baseUrl - the active profile URL (origin is derived from it)
+ * @returns {() => Promise<object>}
+ */
+function makeBootstrapFetcher(win, baseUrl) {
+  const origin = new URL(baseUrl).origin;
+  // Fetch from the PAGE'S authenticated context. The logged-in Protect SPA holds
+  // the session (JSESSIONID/TOKEN) that the API requires; a main-process
+  // net.request does not carry that auth (it only sees JSESSIONID and gets 401).
+  // executeJavaScript runs in the page, so the browser attaches the page's
+  // cookies exactly as the SPA's own API calls do.
+  const js = `fetch(${JSON.stringify(origin + '/proxy/protect/api/bootstrap')}, { credentials: 'include' })
+    .then(function (r) { if (!r.ok) { throw new Error('HTTP ' + r.status); } return r.json(); })`;
+  return function fetchBootstrap() {
+    if (win.isDestroyed() || win.webContents.isDestroyed()) {
+      return Promise.reject(new Error('window destroyed'));
+    }
+    return win.webContents.executeJavaScript(js, true);
+  };
+}
+
+/** userData-based, per-app viewport data dir (identity, key, cert, pins). */
+function viewportDataDir() {
+  return path.join(app.getPath('userData'), 'viewport');
+}
+
+/**
+ * Loads the configured fallback profile when the viewport connection cannot
+ * establish (design: fatal reject / no online within the grace window).
+ * A fallbackProfileId that no longer resolves is treated as "no fallback".
+ * @param {BrowserWindow} win
+ * @returns {boolean} true if a fallback profile was loaded
+ */
+function loadFallbackProfile(win) {
+  const vp = store.getViewportConfig();
+  if (!vp.fallbackProfileId) return false;
+  const profile = store.getProfiles().find((p) => p.id === vp.fallbackProfileId);
+  if (!profile) {
+    vlog(
+      `fallback profile ${vp.fallbackProfileId} no longer exists – staying on viewport connection`,
+    );
+    return false;
+  }
+  vlog(`viewport connection failed – falling back to profile "${profile.name}"`);
+  // Make the render session actually BE the
+  // fallback profile — url AND creds — not just the window's navigation
+  // target. Without this, ipc.js's onConfigLoad keeps returning the viewport
+  // connection (its `enabled`/`url` gate is untouched by a fallback), so
+  // preload.js's unexpected-URL redirect bounces a different-origin fallback
+  // straight back to the viewport, and the auto-login form fills with the
+  // viewport's admin creds instead of the fallback profile's own.
+  renderSession.setRenderCredentialOverride({
+    url: profile.url,
+    username: profile.username,
+    password: profile.password,
+  });
+  store.setActiveProfileId(profile.id);
+  if (!win.isDestroyed()) {
+    win
+      .loadURL(profile.url, { userAgent: USER_AGENT })
+      .catch((e) => vlog(`fallback navigation failed: ${e.message}`));
+  }
+  return true;
+}
+
+/**
+ * Starts Viewport mode for a window if enabled:
+ *  - Adoption mode (dedicated `connection.url` set): runs a real UCP
+ *    AdoptionClient device connection and navigates the window to the
+ *    natively-assigned Live View. Adoption state is pushed to the renderer
+ *    overlay via the 'viewportStatus' IPC channel
+ *    ('registering' → 'online-unassigned' → 'assigned', plus 'reconnecting'
+ *    whenever the adoption link drops).
+ *  - Otherwise: falls back to the bootstrap poller (existing behavior,
+ *    no status pushes).
+ * @param {BrowserWindow} win
+ * @param {{ url:string, username?:string, password?:string }} connection - the
+ *   dedicated viewport connection or the active profile (bootstrap-poller path)
+ * @returns {ViewportBridge|{stop:()=>void}|null}
+ */
+function startViewportBridge(win, connection) {
+  const vp = store.getViewportConfig();
+  if (!vp.enabled) return null;
+
+  // ── Adoption mode: native UCP device connection drives navigation ────────────
+  if (vp.url) {
+    const client = new AdoptionClient();
+    const deviceName = vp.name || `${os.hostname().toUpperCase()}_VIEWPORT`;
+    // Push adoption state to the renderer overlay (preload.js listens on
+    // 'viewportStatus'). Guarded so it is a no-op on a destroyed window and on
+    // the main-process test mock, whose webContents has no send()/isDestroyed().
+    const sendStatus = (s) => {
+      if (win.isDestroyed()) return;
+      const wc = win.webContents;
+      if (!wc || typeof wc.send !== 'function') return;
+      if (typeof wc.isDestroyed === 'function' && wc.isDestroyed()) return;
+      wc.send('viewportStatus', s);
+    };
+    const navigate = (target) => {
+      if (win.isDestroyed()) return;
+      vlog(`native assignment → navigating ${target}`);
+      sendStatus('assigned');
+      win
+        .loadURL(target, { userAgent: USER_AGENT })
+        .catch((e) => vlog(`navigation failed: ${e.message}`));
+    };
+    const handle = startNativeViewport({ client, baseUrl: connection.url, navigate, log: vlog });
+
+    // ── Fallback plumbing: fatal error or no online within the grace
+    // window → load the configured fallback profile instead. ──────────────────
+    let sawOnline = false;
+    let graceTimer = null;
+    const clearGrace = () => {
+      if (graceTimer) {
+        clearTimeout(graceTimer);
+        graceTimer = null;
+      }
+    };
+    if (vp.fallbackProfileId) {
+      graceTimer = setTimeout(() => {
+        if (!sawOnline) {
+          vlog(`no successful online within ${FALLBACK_GRACE_MS / 1000}s grace window`);
+          if (loadFallbackProfile(win)) handle.stop();
+        }
+      }, FALLBACK_GRACE_MS);
+      // Never let this timer keep the process alive on its own – real app
+      // usage always clears it via 'closed'/'online'/fatal-error, but a test
+      // (or an app-quit race) that never reaches those must not hang on a
+      // dangling 60s handle.
+      if (typeof graceTimer.unref === 'function') graceTimer.unref();
+    }
+
+    client.on('online', (v) => {
+      vlog(v ? 'viewport ONLINE' : 'viewport offline');
+      if (v) {
+        sawOnline = true;
+        clearGrace();
+        sendStatus('online-unassigned');
+      } else {
+        // Adoption link dropped (pre-assignment the overlay is still up) —
+        // don't let it linger on "assign a Live View" while offline. The
+        // client reconnects on its own; a successful reconnect re-sends
+        // 'online-unassigned' above.
+        sendStatus('reconnecting');
+      }
+    });
+    client.on('error', (e) => {
+      // Only a STRICT `=== true` is fatal; `undefined`/`false` are transient and
+      // the underlying connection already retries/reconnects on its own.
+      const fatal = e && e.fatal === true;
+      vlog(`adoption error${fatal ? ' (FATAL)' : ''}: ${e && e.message}`);
+      if (fatal) {
+        // Unrecoverable (e.g. rejected fingerprint, bad admin creds) – tear
+        // down, then try the configured fallback profile (no-op when none /
+        // stale).
+        handle.stop();
+        clearGrace();
+        if (!loadFallbackProfile(win)) {
+          // A fatal error with no usable fallback must
+          // NEVER leave the app silently stuck on a dead Protect login page
+          // – log clearly and send the user to config so they can recover
+          // (fix creds, add a fallback profile, etc).
+          vlog('FATAL adoption error with no usable fallback – surfacing via config page');
+          if (!win.isDestroyed()) {
+            win.loadFile(path.join(__dirname, '../html/config.html'));
+          }
+        }
+      }
+    });
+    vlog(`adoption client starting for "${deviceName}" (dataDir ${viewportDataDir()})`);
+    sendStatus('registering');
+    // The dedicated connection's admin creds drive the one-time adopt; a
+    // pre-adopted viewer reconnects keyless via its pinned cert (creds then
+    // only serve the render auto-login, via ipc.js configLoad).
+    client.start({
+      url: connection.url,
+      username: connection.username || undefined,
+      password: connection.password || undefined,
+      deviceName,
+      dataDir: viewportDataDir(),
+    });
+    win.on('closed', () => {
+      clearGrace();
+      handle.stop();
+    });
+    return handle;
+  }
+
+  // ── Fallback: bootstrap poller (non-adoption) ─────────────────────────────────
+  if (!vp.name) return null;
+  const bridge = new ViewportBridge({
+    name: vp.name,
+    fetchBootstrap: makeBootstrapFetcher(win, connection.url),
+  });
+  let currentTarget = null;
+  let lastOk;
+  vlog(`bridge starting for "${vp.name}" (origin ${new URL(connection.url).origin})`);
+  bridge.on('status', (s) => {
+    // Log only on connected/disconnected transitions to keep the log readable.
+    if (s.ok !== lastOk) {
+      lastOk = s.ok;
+      vlog(s.ok ? 'connected to Protect (bootstrap ok)' : `waiting for Protect: ${s.error}`);
+    }
+  });
+  bridge.on('assignment', (liveviewId) => {
+    // A poll can resolve after the window has been closed – never touch a
+    // destroyed window.
+    if (win.isDestroyed()) return;
+    const target = assignmentTargetUrl(connection.url, liveviewId);
+    vlog(`assignment liveviewId=${liveviewId} → target ${target}`);
+    if (target === currentTarget) {
+      vlog('  (same as current target – skipping navigation)');
+      return;
+    }
+    currentTarget = target;
+    win
+      .loadURL(target, { userAgent: USER_AGENT })
+      .catch((e) => vlog(`navigation failed: ${e.message}`));
+  });
+  bridge.start();
+  win.on('closed', () => bridge.stop());
+  return bridge;
+}
+
 // ── Initial page loading ──────────────────────────────────────────────────────
 
 /**
  * Loads the correct initial page:
+ *  - Viewport mode (dedicated connection configured) TOP-LEVEL overrides every
+ *    profile path below — see the viewport branch at the top of this function.
  *  - Config page when no profiles have been saved yet.
  *  - Profile selection page when multiple profiles exist and no startup profile set.
  *  - Directly loads the liveview when one profile or startup profile configured.
@@ -59,6 +307,42 @@ function getSortedDisplays() {
  * @param {{ monitor: number|null, fullscreen: boolean|null, profile: string|null }} [cliArgs]
  */
 async function loadInitialPage(win, cliArgs = {}) {
+  // A normal launch must never inherit a stale render-session override left
+  // by a previous window's fallback in this same process (render-session
+  // state is process-memory, not per-window/per-launch) — always start clean.
+  // Real fallbacks are decided later, asynchronously, from AdoptionClient
+  // events fired well after this point, so clearing here cannot race them.
+  renderSession.clear();
+
+  // ── Viewport mode: top-level override ───────────────────────────────────────
+  // A dedicated connection beats every profile path (select/config included).
+  // NOTE: the `enabled` flag is a UI-only convenience gate, not a security
+  // boundary — an incomplete connection (no url) must never crash or start a
+  // broken adoption; it simply falls through to the unchanged profile flow.
+  const vp = store.getViewportConfig();
+  if (vp.enabled && vp.url) {
+    vlog(`viewport mode active – dedicated connection ${vp.url}`);
+    try {
+      await win.loadURL(vp.url, { userAgent: USER_AGENT });
+    } catch (_) {
+      // did-fail-load handler takes care of navigation to the error page
+    }
+    startViewportBridge(win, {
+      url: vp.url,
+      username: vp.username || undefined,
+      password: vp.password || undefined,
+    });
+    if (!store.isInitialised()) {
+      store.markInitialised();
+    }
+    return;
+  }
+  if (vp.enabled && !vp.url) {
+    vlog(
+      'viewport enabled but no dedicated URL – using profile flow (bootstrap poller if name set)',
+    );
+  }
+
   const profiles = store.getProfiles();
 
   if (profiles.length === 0) {
@@ -107,6 +391,8 @@ async function loadInitialPage(win, cliArgs = {}) {
     } catch (_) {
       // did-fail-load handler takes care of navigation to the error page
     }
+    // Viewport mode: follow the Live View shared to this device.
+    startViewportBridge(win, activeProfile);
   } else {
     // Multiple profiles, no auto-select → show profile selection
     await win.loadFile(path.join(__dirname, '../html/profile-select.html'));

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -133,6 +133,23 @@ function loadFallbackProfile(win) {
 }
 
 /**
+ * Classifies a FATAL adoption error message into a code config.html turns into a
+ * human banner. Only the mint-stage auth failures — `login HTTP 401/403` and
+ * `manage-payload HTTP 401/403` (mint.js) — mean "wrong admin credentials", so we
+ * anchor to that exact shape. Other fatal errors (notably the connection stage's
+ * `fatal UCP upgrade rejected: HTTP 403`, which is a fingerprint/device rejection
+ * on the console — NOT a credentials problem) fall through to the generic
+ * 'failed' banner so the user isn't told to fix a password that's already correct.
+ * @param {string} message
+ * @returns {'auth'|'failed'}
+ */
+function fatalAdoptionErrorCode(message) {
+  return /\b(?:login|manage-payload) HTTP (?:401|403)\b/.test(String(message || ''))
+    ? 'auth'
+    : 'failed';
+}
+
+/**
  * Starts Viewport mode for a window if enabled:
  *  - Adoption mode (dedicated `connection.url` set): runs a real UCP
  *    AdoptionClient device connection and navigates the window to the
@@ -229,9 +246,17 @@ function startViewportBridge(win, connection) {
           // NEVER leave the app silently stuck on a dead Protect login page
           // – log clearly and send the user to config so they can recover
           // (fix creds, add a fallback profile, etc).
-          vlog('FATAL adoption error with no usable fallback – surfacing via config page');
+          const code = fatalAdoptionErrorCode(e && e.message);
+          vlog(
+            `FATAL adoption error (${code}) with no usable fallback – surfacing via config page`,
+          );
           if (!win.isDestroyed()) {
-            win.loadFile(path.join(__dirname, '../html/config.html'));
+            // Pass the reason so config.html can NOTIFY the user why the window
+            // bounced back to settings (e.g. wrong admin username/password)
+            // instead of silently reopening the Viewport tab.
+            win.loadFile(path.join(__dirname, '../html/config.html'), {
+              query: { 'vp-error': code },
+            });
           }
         }
       }

--- a/test/helpers/mock-electron.js
+++ b/test/helpers/mock-electron.js
@@ -114,8 +114,9 @@ class BrowserWindow {
     return Promise.resolve();
   }
 
-  loadFile(filePath) {
+  loadFile(filePath, opts) {
     this._file = filePath;
+    this._loadFileOpts = opts;
     return Promise.resolve();
   }
 

--- a/test/helpers/mock-electron.js
+++ b/test/helpers/mock-electron.js
@@ -62,6 +62,9 @@ const app = {
   relaunch: () => {},
   quit: () => {},
   exit: () => {},
+  // Single-instance lock: default to "we got the lock" (the common case).
+  // Tests that simulate a duplicate launch override this to return false.
+  requestSingleInstanceLock: () => true,
 };
 
 // ── BrowserWindow mock ────────────────────────────────────────────────────────
@@ -178,6 +181,14 @@ class BrowserWindow {
     return this._visible;
   }
 
+  isMinimized() {
+    return this._minimized ?? false;
+  }
+
+  restore() {
+    this._minimized = false;
+  }
+
   isDestroyed() {
     return this._destroyed;
   }
@@ -186,6 +197,14 @@ class BrowserWindow {
     this._destroyed = true;
   }
 }
+
+// Captured immediately, before any test can override them. Some tests stub
+// BrowserWindow.getAllWindows (a static method, shared across all tests/files
+// running in this process) to simulate 0/1 windows; without restoring it in
+// resetElectronMocks() below, that stub leaks into every test that runs
+// afterwards and returns a fabricated window instead of the real one.
+const originalBrowserWindowGetAllWindows = BrowserWindow.getAllWindows;
+const originalBrowserWindowFromWebContents = BrowserWindow.fromWebContents;
 
 // ── Menu mock ─────────────────────────────────────────────────────────────────
 
@@ -367,6 +386,11 @@ function resetElectronMocks() {
   app.relaunch = () => {};
   app.quit = () => {};
   app.exit = () => {};
+  app.requestSingleInstanceLock = () => true;
+
+  // Undo any per-test stub of these static methods (see capture above).
+  BrowserWindow.getAllWindows = originalBrowserWindowGetAllWindows;
+  BrowserWindow.fromWebContents = originalBrowserWindowFromWebContents;
 
   screen._displays = null;
 }

--- a/test/js/preload.test.js
+++ b/test/js/preload.test.js
@@ -138,6 +138,7 @@ describe('preload.js – API surface contract', () => {
       'configSave',
       'displaysGet',
       'launchProfile',
+      'onViewportStatus',
       'openConfig',
       'openDevTools',
       'openExternal',
@@ -152,6 +153,9 @@ describe('preload.js – API surface contract', () => {
       'startupSettingsSet',
       'switchNextProfile',
       'toggleFullscreen',
+      'viewportConfigGet',
+      'viewportConfigSet',
+      'viewportRemove',
     ].sort();
     assert.deepStrictEqual(Object.keys(exposed.electronAPI).sort(), expectedMethods);
   });
@@ -281,6 +285,14 @@ describe('preload.js – IPC send channel contracts', () => {
     assert.strictEqual(sentMessages[baseIdx].args.length, 0);
   });
 
+  test('viewportConfigSet sends on channel "viewportConfigSet" with the settings object', () => {
+    const { exposed, sentMessages, baseIdx } = runPreloadInSandbox();
+    exposed.electronAPI.viewportConfigSet({ enabled: true, name: 'Wall TV' });
+    assert.strictEqual(sentMessages[baseIdx].channel, 'viewportConfigSet');
+    assert.strictEqual(sentMessages[baseIdx].args.length, 1);
+    assert.deepStrictEqual(sentMessages[baseIdx].args[0], { enabled: true, name: 'Wall TV' });
+  });
+
   test('reset sends on channel "reset" with 0 arguments', () => {
     const { exposed, sentMessages, baseIdx } = runPreloadInSandbox();
     exposed.electronAPI.reset();
@@ -324,6 +336,19 @@ describe('preload.js – IPC invoke channel contracts and return-value pass-thro
     const { exposed } = runPreloadInSandbox(undefined);
     const result = await exposed.electronAPI.configLoad();
     assert.strictEqual(result, undefined);
+  });
+
+  test('viewportConfigGet invokes channel "viewportConfigGet" with 0 arguments', async () => {
+    const { exposed, invokedMessages } = runPreloadInSandbox();
+    await exposed.electronAPI.viewportConfigGet();
+    assert.strictEqual(invokedMessages[0].channel, 'viewportConfigGet');
+    assert.strictEqual(invokedMessages[0].args.length, 0);
+  });
+
+  test('viewportConfigGet: return value is passed through from invoke', async () => {
+    const { exposed } = runPreloadInSandbox({ enabled: true, name: 'Wall TV' });
+    const result = await exposed.electronAPI.viewportConfigGet();
+    assert.deepStrictEqual(result, { enabled: true, name: 'Wall TV' });
   });
 
   test('profilesLoad invokes channel "profilesLoad"', async () => {

--- a/test/js/preload.test.js
+++ b/test/js/preload.test.js
@@ -156,6 +156,7 @@ describe('preload.js – API surface contract', () => {
       'viewportConfigGet',
       'viewportConfigSet',
       'viewportRemove',
+      'viewportSharedViewsStatus',
     ].sort();
     assert.deepStrictEqual(Object.keys(exposed.electronAPI).sort(), expectedMethods);
   });

--- a/test/js/viewport-settings.test.js
+++ b/test/js/viewport-settings.test.js
@@ -195,4 +195,28 @@ describe('viewport-settings.js – buildViewportSetPayload', () => {
     assert.equal(p.passwordChanged, false);
     assert.equal(p.fallbackProfileId, null, 'empty dropdown value maps to null');
   });
+
+  test("adoptionErrorBanner('auth') explains bad admin credentials", () => {
+    const vs = loadModule();
+    const b = vs.adoptionErrorBanner('auth');
+    assert.ok(b, 'auth code must return a banner');
+    assert.match(b.title, /registration failed/i);
+    assert.match(b.detail, /username or password/i);
+    assert.match(b.detail, /Save & Restart/);
+  });
+
+  test("adoptionErrorBanner('failed') is a generic registration failure", () => {
+    const vs = loadModule();
+    const b = vs.adoptionErrorBanner('failed');
+    assert.ok(b, 'failed code must return a banner');
+    assert.match(b.title, /registration failed/i);
+    assert.match(b.detail, /credentials|address/i);
+  });
+
+  test('adoptionErrorBanner returns null for absent/unknown codes', () => {
+    const vs = loadModule();
+    assert.equal(vs.adoptionErrorBanner(''), null);
+    assert.equal(vs.adoptionErrorBanner(undefined), null);
+    assert.equal(vs.adoptionErrorBanner('something-else'), null);
+  });
 });

--- a/test/js/viewport-settings.test.js
+++ b/test/js/viewport-settings.test.js
@@ -1,0 +1,198 @@
+'use strict';
+
+/**
+ * @file test/js/viewport-settings.test.js
+ * @description Contract tests for src/html/viewport-settings.js — the pure
+ * form↔config mapping used by the 2c Viewport card in config.html.
+ * Evaluated in a vm sandbox (same pattern as debug-block.test.js); the
+ * functions are DOM-free so the sandbox only needs a `window` object.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const source = fs.readFileSync(
+  path.resolve(__dirname, '../../src/html/viewport-settings.js'),
+  'utf8',
+);
+
+function loadModule() {
+  // NOTE: vm.runInNewContext() (the debug-block.test.js pattern) executes the
+  // source in a brand-new V8 context/realm. Any object literals the module
+  // creates at call time (e.g. the return value of viewportFormFromConfig)
+  // therefore carry that realm's Object.prototype, which fails
+  // assert.deepStrictEqual() against plain object literals written in this
+  // file — Node reports "same structure but are not reference-equal" even
+  // though the values are identical. vm.runInThisContext() runs the module
+  // in THIS realm instead (still isolated from the module's internal scope
+  // via its own IIFE), so returned objects compare equal by value as
+  // expected, while still keeping the module free of require()/module
+  // globals other than the injected `window`.
+  if (!global.window) global.window = {};
+  vm.runInThisContext(source, { filename: 'viewport-settings.js' });
+  const api = global.window.viewportSettings;
+  delete global.window.viewportSettings;
+  return api;
+}
+
+const REDACTED = {
+  enabled: true,
+  name: 'Wall TV',
+  url: 'https://nvr.local',
+  username: 'admin',
+  fallbackProfileId: 'p1',
+  hasPassword: true,
+  encryptionAvailable: true,
+  defaultName: 'HOSTY_VIEWPORT',
+};
+
+describe('viewport-settings.js – viewportFormFromConfig', () => {
+  test('maps every redacted field onto form state', () => {
+    const vs = loadModule();
+    assert.deepStrictEqual(vs.viewportFormFromConfig(REDACTED), {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      fallbackProfileId: 'p1',
+      namePlaceholder: 'HOSTY_VIEWPORT',
+      passwordPlaceholder: 'unchanged',
+      showEncWarning: false,
+    });
+  });
+
+  test('empty/undefined config yields safe defaults', () => {
+    const vs = loadModule();
+    assert.deepStrictEqual(vs.viewportFormFromConfig(undefined), {
+      enabled: false,
+      name: '',
+      url: '',
+      username: '',
+      fallbackProfileId: '',
+      namePlaceholder: '',
+      passwordPlaceholder: '',
+      showEncWarning: false,
+    });
+  });
+
+  test('encryptionAvailable:false raises the warning flag; no stored password → empty placeholder', () => {
+    const vs = loadModule();
+    const form = vs.viewportFormFromConfig({
+      ...REDACTED,
+      encryptionAvailable: false,
+      hasPassword: false,
+    });
+    assert.equal(form.showEncWarning, true);
+    assert.equal(form.passwordPlaceholder, '');
+  });
+});
+
+describe('viewport-settings.js – validateViewportForm', () => {
+  const base = {
+    enabled: true,
+    url: 'https://nvr.local',
+    username: 'admin',
+    passwordValue: '',
+    passwordChanged: false,
+  };
+
+  test('disabled form is always valid', () => {
+    const vs = loadModule();
+    assert.deepStrictEqual(vs.validateViewportForm({ enabled: false }, REDACTED), { ok: true });
+  });
+
+  test('enabled without url fails on viewport-url', () => {
+    const vs = loadModule();
+    const r = vs.validateViewportForm({ ...base, url: '' }, REDACTED);
+    assert.equal(r.ok, false);
+    assert.equal(r.field, 'viewport-url');
+  });
+
+  test('url must start with http(s)://', () => {
+    const vs = loadModule();
+    const r = vs.validateViewportForm({ ...base, url: 'nvr.local' }, REDACTED);
+    assert.equal(r.ok, false);
+    assert.equal(r.field, 'viewport-url');
+  });
+
+  test('enabled without username fails on viewport-username', () => {
+    const vs = loadModule();
+    const r = vs.validateViewportForm({ ...base, username: '' }, REDACTED);
+    assert.equal(r.ok, false);
+    assert.equal(r.field, 'viewport-username');
+  });
+
+  test('no stored password and no new password fails on viewport-password', () => {
+    const vs = loadModule();
+    const r = vs.validateViewportForm(base, { ...REDACTED, hasPassword: false });
+    assert.equal(r.ok, false);
+    assert.equal(r.field, 'viewport-password');
+  });
+
+  test('stored password + unchanged passes; new password passes', () => {
+    const vs = loadModule();
+    assert.deepStrictEqual(vs.validateViewportForm(base, REDACTED), { ok: true });
+    assert.deepStrictEqual(
+      vs.validateViewportForm(
+        { ...base, passwordChanged: true, passwordValue: 'new' },
+        { ...REDACTED, hasPassword: false },
+      ),
+      { ok: true },
+    );
+  });
+
+  test('passwordChanged with an empty value fails even when a password is stored', () => {
+    const vs = loadModule();
+    const r = vs.validateViewportForm(
+      { ...base, passwordChanged: true, passwordValue: '' },
+      REDACTED,
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.field, 'viewport-password');
+  });
+});
+
+describe('viewport-settings.js – buildViewportSetPayload', () => {
+  test('trims fields, forwards passwordChanged with the value', () => {
+    const vs = loadModule();
+    assert.deepStrictEqual(
+      vs.buildViewportSetPayload({
+        enabled: true,
+        name: '  Wall TV ',
+        url: ' https://nvr.local ',
+        username: ' admin ',
+        passwordValue: 'hunter2',
+        passwordChanged: true,
+        fallbackProfileId: 'p1',
+      }),
+      {
+        enabled: true,
+        name: 'Wall TV',
+        url: 'https://nvr.local',
+        username: 'admin',
+        password: 'hunter2',
+        passwordChanged: true,
+        fallbackProfileId: 'p1',
+      },
+    );
+  });
+
+  test('unchanged password sends empty password + passwordChanged:false (retention contract)', () => {
+    const vs = loadModule();
+    const p = vs.buildViewportSetPayload({
+      enabled: true,
+      name: 'V',
+      url: 'https://x',
+      username: 'a',
+      passwordValue: 'typed-then-cleared-should-be-ignored',
+      passwordChanged: false,
+      fallbackProfileId: '',
+    });
+    assert.equal(p.password, '');
+    assert.equal(p.passwordChanged, false);
+    assert.equal(p.fallbackProfileId, null, 'empty dropdown value maps to null');
+  });
+});

--- a/test/main/app.test.js
+++ b/test/main/app.test.js
@@ -18,6 +18,10 @@
  *  - window-all-closed quits on non-darwin, stays on darwin
  *  - activate creates a new window only when none exist
  *  - app.js exports nothing (no public API)
+ *  - single-instance lock: a duplicate launch quits immediately without
+ *    running whenReady startup (no second AdoptionClient/window)
+ *  - single-instance lock: the holder registers a second-instance handler
+ *    that surfaces (restores/shows/focuses) its existing window
  */
 
 const { test, describe, beforeEach, afterEach } = require('node:test');
@@ -336,5 +340,130 @@ describe('app.js – activate (macOS re-open)', () => {
       countAfterStart,
       'createMainWindow must not be called when a window already exists',
     );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SINGLE-INSTANCE LOCK CONTRACT
+// ─────────────────────────────────────────────────────────────────────────────
+// Viewport mode: two concurrent instances would each run their own
+// AdoptionClient and adopt as the SAME MAC (derived from the shared userData
+// dir), fighting each other on the NVR. requestSingleInstanceLock() must gate
+// startup so a duplicate launch never reaches whenReady().
+
+describe('app.js – single-instance lock', () => {
+  beforeEach(() => {
+    registerIpcHandlersCalled = false;
+    createMainWindowCalled = false;
+    createMainWindowCount = 0;
+    callOrder = [];
+    resetElectronMocks();
+    installElectronMock();
+    installMocks();
+  });
+
+  afterEach(() => {
+    uninstallMocks();
+    uninstallElectronMock();
+    delete require.cache[require.resolve('../../src/main/app')];
+  });
+
+  test('requestSingleInstanceLock is called exactly once, synchronously at require-time', () => {
+    let callCount = 0;
+    app.requestSingleInstanceLock = () => {
+      callCount++;
+      return true;
+    };
+    requireFreshApp();
+    // No await/tick needed – must happen before whenReady, i.e. during require().
+    assert.strictEqual(callCount, 1);
+  });
+
+  test('lock NOT acquired: app.quit is called', () => {
+    app.requestSingleInstanceLock = () => false;
+    let quitCalled = false;
+    app.quit = () => {
+      quitCalled = true;
+    };
+    requireFreshApp();
+    assert.strictEqual(quitCalled, true, 'a duplicate launch must call app.quit()');
+  });
+
+  test('lock NOT acquired: whenReady startup never runs (no second AdoptionClient/window)', async () => {
+    app.requestSingleInstanceLock = () => false;
+    app.quit = () => {};
+    requireFreshApp();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(
+      registerIpcHandlersCalled,
+      false,
+      'registerIpcHandlers must not run for a duplicate launch',
+    );
+    assert.strictEqual(
+      createMainWindowCalled,
+      false,
+      'createMainWindow must not run for a duplicate launch',
+    );
+  });
+
+  test('lock acquired: whenReady startup still runs normally', async () => {
+    app.requestSingleInstanceLock = () => true;
+    requireFreshApp();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(registerIpcHandlersCalled, true);
+    assert.strictEqual(createMainWindowCalled, true);
+  });
+
+  test('lock acquired: a second-instance handler is registered', () => {
+    app.requestSingleInstanceLock = () => true;
+    requireFreshApp();
+    assert.ok(
+      getAppHandlers()['second-instance'] && getAppHandlers()['second-instance'].length > 0,
+      'a second-instance listener must be registered when this instance holds the lock',
+    );
+  });
+
+  test('second-instance: existing window is shown and focused', async () => {
+    app.requestSingleInstanceLock = () => true;
+    requireFreshApp();
+    await new Promise((r) => setImmediate(r)); // let whenReady create the window
+
+    const win = BrowserWindow.getAllWindows()[0];
+    win.hide();
+    let focusCalled = false;
+    win.focus = () => {
+      focusCalled = true;
+    };
+
+    app.emit('second-instance');
+
+    assert.strictEqual(win.isVisible(), true, 'window must be shown');
+    assert.strictEqual(focusCalled, true, 'window must be focused');
+  });
+
+  test('second-instance: minimized window is restored before being shown', async () => {
+    app.requestSingleInstanceLock = () => true;
+    requireFreshApp();
+    await new Promise((r) => setImmediate(r));
+
+    const win = BrowserWindow.getAllWindows()[0];
+    win._minimized = true;
+    let restoreCalled = false;
+    const originalRestore = win.restore.bind(win);
+    win.restore = () => {
+      restoreCalled = true;
+      originalRestore();
+    };
+
+    app.emit('second-instance');
+
+    assert.strictEqual(restoreCalled, true, 'a minimized window must be restored');
+  });
+
+  test('second-instance: does not throw when no window exists', () => {
+    app.requestSingleInstanceLock = () => true;
+    requireFreshApp();
+    BrowserWindow.getAllWindows = () => [];
+    assert.doesNotThrow(() => app.emit('second-instance'));
   });
 });

--- a/test/main/ipc.test.js
+++ b/test/main/ipc.test.js
@@ -19,6 +19,7 @@ const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const { Module } = require('node:module');
 const path = require('node:path');
+const os = require('node:os');
 
 const {
   installElectronMock,
@@ -35,6 +36,12 @@ const {
 
 const MockStore = require('../helpers/mock-store');
 let mockStoreInstance;
+
+// render-session.js is intentionally NOT mocked (it has no Electron/Node I/O
+// dependency, and ipc.js's onConfigLoad must observe the SAME process-memory
+// singleton window.js writes to in real usage) — require the real module and
+// reset it explicitly so no test's override leaks into the next.
+const renderSession = require('../../src/main/render-session');
 
 const storeApi = {
   clearAll: () => mockStoreInstance.clear(),
@@ -71,6 +78,38 @@ const storeApi = {
     });
     mockStoreInstance.set('startupSettings', { ...current, ...settings });
   },
+  getViewportConfig: () =>
+    mockStoreInstance.get('viewport', {
+      enabled: false,
+      name: '',
+      url: '',
+      username: '',
+      password: '',
+      fallbackProfileId: null,
+    }),
+  getViewportConfigRedacted: () => {
+    const v = storeApi.getViewportConfig();
+    return {
+      enabled: v.enabled,
+      name: v.name,
+      url: v.url,
+      username: v.username,
+      fallbackProfileId: v.fallbackProfileId,
+      hasPassword: !!v.password,
+      encryptionAvailable: true,
+      defaultName: 'TESTHOST_VIEWPORT',
+    };
+  },
+  setViewportConfig: (settings) => {
+    // Mirrors store.js semantics enough for pass-through assertions.
+    const { password, passwordChanged, ...rest } = settings || {};
+    const merged = { ...storeApi.getViewportConfig(), ...rest };
+    merged.password = passwordChanged
+      ? `enc(${password || ''})`
+      : storeApi.getViewportConfig().password;
+    mockStoreInstance.set('viewport', merged);
+    return merged;
+  },
   isInitialised: () => mockStoreInstance.has('init'),
   saveWindowBounds: (bounds) => mockStoreInstance.set('bounds', bounds),
   isPortable: false,
@@ -82,6 +121,26 @@ const trayMock = {
     trayUpdateCalls.push(win);
   },
 };
+
+// ── viewportRemove dependency mocks (Task 7) ─────────────────────────────────
+// ipc.js requires these lazily INSIDE onViewportRemove, so intercepting
+// Module._load at handler-call time is the injection seam (same pattern as
+// store/tray above). No network, no real fs.
+
+let adminApiMock; // reassigned per test in the viewportRemove describe
+let identityLoaderMock;
+let fsRmCalls = [];
+const IPC_JS_SUFFIX = path.join('src', 'main', 'ipc.js');
+const fsMock = {
+  ...require('node:fs'),
+  rmSync: (target, opts) => {
+    fsRmCalls.push({ target, opts });
+  },
+};
+// Never exercised (admin-api is fully mocked) — present so the handler's
+// require()s resolve without touching the real modules.
+const mintMock = { httpJson: async () => ({ status: 500, body: '', setCookie: [] }) };
+const tokenMock = { buildLoginRequest: () => ({}) };
 
 const originalLoad = Module._load;
 
@@ -95,6 +154,20 @@ function installMocks() {
     }
     if (request === path.resolve(__dirname, '../../src/main/tray') || request === './tray') {
       return trayMock;
+    }
+    if (request === './viewport/adoption/admin-api') return adminApiMock;
+    if (request === './viewport/adoption/identity') return identityLoaderMock;
+    if (request === './viewport/adoption/mint') return mintMock;
+    if (request === './viewport/adoption/token') return tokenMock;
+    // Only ipc.js gets the fake fs (rmSync recorder) — everything else keeps
+    // the real module.
+    if (
+      request === 'node:fs' &&
+      parent &&
+      parent.filename &&
+      parent.filename.endsWith(IPC_JS_SUFFIX)
+    ) {
+      return fsMock;
     }
     return originalLoad.call(this, request, parent, isMain);
   };
@@ -133,9 +206,10 @@ describe('ipc.js – module boundary contract', () => {
     uninstallElectronMock();
   });
 
-  test('exports exactly { makeWindowLogHandler, registerF11Handler, registerIpcHandlers }', () => {
+  test('exports exactly { currentLogger, makeWindowLogHandler, registerF11Handler, registerIpcHandlers }', () => {
     const mod = requireFreshIpc();
     assert.deepStrictEqual(Object.keys(mod).sort(), [
+      'currentLogger',
       'makeWindowLogHandler',
       'registerF11Handler',
       'registerIpcHandlers',
@@ -192,6 +266,7 @@ describe('ipc.js – registerIpcHandlers registers exact channel set', () => {
       'switchNextProfile',
       'toggleFullscreen',
       'upv:log',
+      'viewportConfigSet',
     ];
     assert.deepStrictEqual(Object.keys(handlers).sort(), expectedOnChannels);
   });
@@ -207,6 +282,8 @@ describe('ipc.js – registerIpcHandlers registers exact channel set', () => {
       'profilesLoad',
       'startupProfileGet',
       'startupSettingsGet',
+      'viewportConfigGet',
+      'viewportRemove',
     ];
     assert.deepStrictEqual(Object.keys(handleHandlers).sort(), expectedHandleChannels);
   });
@@ -260,6 +337,7 @@ describe('ipc.js – handler implementations', () => {
     resetElectronMocks();
     installElectronMock();
     installMocks();
+    renderSession.clear();
     const { registerIpcHandlers } = requireFreshIpc();
     registerIpcHandlers();
     handlers = getIpcMainHandlers();
@@ -270,20 +348,23 @@ describe('ipc.js – handler implementations', () => {
   });
 
   afterEach(() => {
+    renderSession.clear();
     uninstallMocks();
     uninstallElectronMock();
   });
 
   // ── reset ─────────────────────────────────────────────────────────────────
 
-  test('reset: clears store, calls relaunch then quit', () => {
+  test('reset: clears store, calls relaunch then exit', () => {
     let relaunchCalled = false;
-    let quitCalled = false;
+    let exitCalled = false;
     app.relaunch = () => {
       relaunchCalled = true;
     };
-    app.quit = () => {
-      quitCalled = true;
+    // reset uses app.exit(0) (not quit) so the relaunched instance can acquire
+    // the single-instance lock promptly — see onReset comment.
+    app.exit = () => {
+      exitCalled = true;
     };
 
     mockStoreInstance._seed({ profiles: [{ id: 'x' }], init: true });
@@ -291,22 +372,22 @@ describe('ipc.js – handler implementations', () => {
 
     assert.strictEqual(mockStoreInstance._dump().profiles, undefined);
     assert.strictEqual(relaunchCalled, true);
-    assert.strictEqual(quitCalled, true);
+    assert.strictEqual(exitCalled, true);
   });
 
-  test('reset: relaunch is called before quit', () => {
+  test('reset: relaunch is called before exit', () => {
     const order = [];
     app.relaunch = () => {
       order.push('relaunch');
     };
-    app.quit = () => {
-      order.push('quit');
+    app.exit = () => {
+      order.push('exit');
     };
     handlers['reset']();
-    assert.deepStrictEqual(order, ['relaunch', 'quit']);
+    assert.deepStrictEqual(order, ['relaunch', 'exit']);
   });
 
-  test('reset: clearAll is called before relaunch (full order: clearAll → relaunch → quit)', () => {
+  test('reset: clearAll is called before relaunch (full order: clearAll → relaunch → exit)', () => {
     const order = [];
     mockStoreInstance._seed({ profiles: [{ id: 'x' }] });
     const origClear = mockStoreInstance.clear.bind(mockStoreInstance);
@@ -317,11 +398,11 @@ describe('ipc.js – handler implementations', () => {
     app.relaunch = () => {
       order.push('relaunch');
     };
-    app.quit = () => {
-      order.push('quit');
+    app.exit = () => {
+      order.push('exit');
     };
     handlers['reset']();
-    assert.deepStrictEqual(order, ['clearAll', 'relaunch', 'quit']);
+    assert.deepStrictEqual(order, ['clearAll', 'relaunch', 'exit']);
   });
 
   test('reset: store is empty after clearAll – no residual state', () => {
@@ -511,6 +592,209 @@ describe('ipc.js – handler implementations', () => {
     assert.strictEqual(result.url, 'https://exact');
     assert.strictEqual(result.username, 'exactUser');
     assert.strictEqual(result.password, 'exactPw');
+  });
+
+  test('configLoad: Viewport mode → returns the DEDICATED connection, not the profile', async () => {
+    mockStoreInstance.set('_config', {
+      url: 'https://profile.local',
+      username: 'pu',
+      password: 'pp',
+    });
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2', // mock store returns the decrypted form
+      fallbackProfileId: null,
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.deepEqual(result, {
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      viewportName: 'Wall TV',
+    });
+  });
+
+  test('configLoad: viewport disabled → active profile (unchanged behavior)', async () => {
+    mockStoreInstance.set('_config', {
+      url: 'https://profile.local',
+      username: 'pu',
+      password: 'pp',
+    });
+    mockStoreInstance.set('viewport', {
+      enabled: false,
+      name: '',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'x',
+      fallbackProfileId: null,
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.deepEqual(result, { url: 'https://profile.local', username: 'pu', password: 'pp' });
+  });
+
+  test('configLoad: viewport enabled WITHOUT url (Phase-1 poller mode) → active profile', async () => {
+    mockStoreInstance.set('_config', {
+      url: 'https://profile.local',
+      username: 'pu',
+      password: 'pp',
+    });
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: 'Wall TV',
+      url: '',
+      username: '',
+      password: '',
+      fallbackProfileId: null,
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.deepEqual(result, { url: 'https://profile.local', username: 'pu', password: 'pp' });
+  });
+
+  // ── configLoad: viewportName (loading-overlay 2c) ──────────────────────────
+  // The "Loading Viewport" overlay (preload.js) keys off this field, which
+  // must appear ONLY on the dedicated-viewport-connection path.
+
+  test('configLoad: Viewport mode → includes viewportName (the configured name)', async () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      fallbackProfileId: null,
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.strictEqual(result.viewportName, 'Wall TV');
+  });
+
+  test('configLoad: Viewport mode with empty name → viewportName falls back to <hostname>_VIEWPORT default', async () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: '',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      fallbackProfileId: null,
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.strictEqual(result.viewportName, `${os.hostname().toUpperCase()}_VIEWPORT`);
+  });
+
+  test('configLoad: profile mode (viewport disabled) → NO viewportName key', async () => {
+    mockStoreInstance.set('_config', {
+      url: 'https://profile.local',
+      username: 'pu',
+      password: 'pp',
+    });
+    mockStoreInstance.set('viewport', {
+      enabled: false,
+      name: '',
+      url: '',
+      username: '',
+      password: '',
+      fallbackProfileId: null,
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.ok(!('viewportName' in result), 'profile mode must not carry viewportName');
+  });
+
+  test('configLoad: render-session override (fallback) → NO viewportName key', async () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      fallbackProfileId: 'fb',
+    });
+    renderSession.setRenderCredentialOverride({
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.ok(!('viewportName' in result), 'fallback override must not carry viewportName');
+  });
+
+  // ── configLoad: render-session override (2c fix, I1) ──────────────────────
+  // Simulates what window.js's loadFallbackProfile does on a real fallback:
+  // it never touches the stored viewport config, it only sets the in-memory
+  // override — so these tests seed an "enabled" viewport connection AND set
+  // the override, to prove the override wins.
+
+  test('configLoad: render-session override set → returns the FALLBACK PROFILE, not the viewport connection', async () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      fallbackProfileId: 'fb',
+    });
+    renderSession.setRenderCredentialOverride({
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.deepEqual(result, {
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+  });
+
+  test('configLoad: render-session override set → also wins over profile mode (viewport disabled)', async () => {
+    mockStoreInstance.set('_config', {
+      url: 'https://profile.local',
+      username: 'pu',
+      password: 'pp',
+    });
+    renderSession.setRenderCredentialOverride({
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+    const result = await handleHandlers['configLoad']();
+    assert.deepEqual(result, {
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+  });
+
+  test('configLoad: no override (normal launch) → Viewport mode still returns the dedicated connection unaffected', async () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      fallbackProfileId: null,
+    });
+    // no renderSession.setRenderCredentialOverride() call – default state
+    const result = await handleHandlers['configLoad']();
+    assert.deepEqual(result, {
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      viewportName: 'Wall TV',
+    });
+  });
+
+  test('configLoad: override cleared → subsequent call falls back through to normal resolution', async () => {
+    mockStoreInstance.set('_config', {
+      url: 'https://profile.local',
+      username: 'pu',
+      password: 'pp',
+    });
+    renderSession.setRenderCredentialOverride({ url: 'https://fallback.local' });
+    renderSession.clear();
+    const result = await handleHandlers['configLoad']();
+    assert.deepEqual(result, { url: 'https://profile.local', username: 'pu', password: 'pp' });
   });
 
   // ── openConfig ───────────────────────────────────────────────────────────
@@ -755,6 +1039,70 @@ describe('ipc.js – handler implementations', () => {
     assert.strictEqual(mockStoreInstance.get('startupProfileId'), true);
   });
 
+  // ── viewportConfigGet / viewportConfigSet (2c: redacted get, encrypting set) ─
+
+  test('viewportConfigGet: returns the REDACTED config — no password key', async () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'enc(hunter2)',
+      fallbackProfileId: 'p1',
+    });
+    const result = await handleHandlers['viewportConfigGet']();
+    assert.ok(!('password' in result), 'redacted config must not carry the password');
+    assert.deepEqual(result, {
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      fallbackProfileId: 'p1',
+      hasPassword: true,
+      encryptionAvailable: true,
+      defaultName: 'TESTHOST_VIEWPORT',
+    });
+  });
+
+  test('viewportConfigGet: default shape when unset (hasPassword false)', async () => {
+    const result = await handleHandlers['viewportConfigGet']();
+    assert.equal(result.enabled, false);
+    assert.equal(result.hasPassword, false);
+    assert.ok(!('password' in result));
+  });
+
+  test('viewportConfigSet: passes the full payload (incl. passwordChanged) to the store', () => {
+    handlers['viewportConfigSet'](
+      {},
+      {
+        enabled: true,
+        name: 'Wall TV',
+        url: 'https://nvr.local',
+        username: 'admin',
+        password: 'hunter2',
+        passwordChanged: true,
+        fallbackProfileId: null,
+      },
+    );
+    const stored = mockStoreInstance.get('viewport');
+    assert.equal(stored.password, 'enc(hunter2)', 'store owns encryption');
+    assert.equal(stored.url, 'https://nvr.local');
+    assert.ok(!('passwordChanged' in stored));
+  });
+
+  test('viewportConfigSet: passwordChanged absent retains the stored password', () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      name: '',
+      url: '',
+      username: '',
+      password: 'enc(old)',
+      fallbackProfileId: null,
+    });
+    handlers['viewportConfigSet']({}, { enabled: false, name: 'Renamed' });
+    assert.equal(mockStoreInstance.get('viewport').password, 'enc(old)');
+  });
+
   // ── switchNextProfile ─────────────────────────────────────────────────────
 
   test('switchNextProfile: loads profile-select.html when >1 profiles exist', () => {
@@ -912,6 +1260,201 @@ describe('ipc.js – handler implementations', () => {
     mockStoreInstance.set('profiles', [{ id: 'p1', name: 'P1', url: 'u1' }]);
     assert.doesNotThrow(() => handlers['launchProfile'](makeEvent(win), null));
     assert.strictEqual(mockStoreInstance.get('activeProfileId'), undefined);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// viewportRemove CONTRACT (Task 7)
+// Deletes the emulated viewer from Protect, resets the local identity, and
+// disables Viewport mode. A login/reach failure OR a rejected delete (viewer
+// found but non-2xx) must NOT clear the identity (so a retry can still find
+// the device row by MAC). The result payload must never carry the admin
+// password.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ipc.js – viewportRemove', () => {
+  let handleHandlers;
+  let loginCalls;
+  let findCalls;
+  let deleteCalls;
+
+  const VP_CONNECTED = {
+    enabled: true,
+    name: 'Wall TV',
+    url: 'https://nvr.local',
+    username: 'admin',
+    password: 'hunter2', // mock store returns the decrypted form
+    fallbackProfileId: null,
+  };
+
+  beforeEach(() => {
+    mockStoreInstance = new MockStore();
+    resetElectronMocks();
+    installElectronMock();
+    installMocks();
+    fsRmCalls = [];
+    loginCalls = [];
+    findCalls = [];
+    deleteCalls = [];
+    adminApiMock = {
+      login: async (url, username, password, dep) => {
+        loginCalls.push({ url, username, password, dep });
+        return { cookie: 'TOKEN=abc' };
+      },
+      findViewerByMac: async (url, cookie, mac, dep) => {
+        findCalls.push({ url, cookie, mac, dep });
+        return { id: 'viewer-1', mac: 'AABBCCDDEEFF' };
+      },
+      deleteViewer: async (url, cookie, id, dep) => {
+        deleteCalls.push({ url, cookie, id, dep });
+        return true;
+      },
+    };
+    identityLoaderMock = {
+      loadOrCreateIdentity: (dir) => ({
+        cert: 'CERT',
+        key: 'KEY',
+        mac: 'AABBCCDDEEFF',
+        ident: 'uuid-1',
+        _dir: dir,
+      }),
+    };
+    mockStoreInstance.set('viewport', { ...VP_CONNECTED });
+    const { registerIpcHandlers } = requireFreshIpc();
+    registerIpcHandlers();
+    handleHandlers = getIpcMainHandleHandlers();
+  });
+
+  afterEach(() => {
+    uninstallMocks();
+    uninstallElectronMock();
+  });
+
+  test('happy path: logs in with stored creds, deletes the viewer found by identity MAC → {ok:true, removed:true}', async () => {
+    const result = await handleHandlers['viewportRemove']();
+    assert.equal(result.ok, true);
+    assert.equal(result.removed, true);
+    assert.equal(loginCalls.length, 1);
+    assert.equal(loginCalls[0].url, 'https://nvr.local');
+    assert.equal(loginCalls[0].username, 'admin');
+    assert.equal(loginCalls[0].password, 'hunter2', 'login uses the decrypted stored password');
+    assert.equal(findCalls.length, 1);
+    assert.equal(findCalls[0].cookie, 'TOKEN=abc');
+    assert.equal(findCalls[0].mac, 'AABBCCDDEEFF', 'lookup uses the on-disk identity MAC');
+    assert.equal(deleteCalls.length, 1);
+    assert.equal(deleteCalls[0].id, 'viewer-1');
+  });
+
+  test('happy path: clears the identity dir (userData/viewport, recursive+force)', async () => {
+    await handleHandlers['viewportRemove']();
+    assert.equal(fsRmCalls.length, 1);
+    assert.equal(fsRmCalls[0].target, path.join('/mock/userData', 'viewport'));
+    assert.deepEqual(fsRmCalls[0].opts, { recursive: true, force: true });
+  });
+
+  test('happy path: disables viewport mode but RETAINS the stored password ciphertext', async () => {
+    await handleHandlers['viewportRemove']();
+    const stored = mockStoreInstance.get('viewport');
+    assert.equal(stored.enabled, false, 'viewport mode must be disabled');
+    assert.equal(
+      stored.password,
+      'hunter2',
+      'passwordChanged:false must retain the stored ciphertext',
+    );
+    assert.equal(stored.url, 'https://nvr.local', 'connection settings survive for a re-enable');
+    assert.equal(stored.username, 'admin');
+  });
+
+  test('happy path: result carries no secret (no password key, no password value)', async () => {
+    const result = await handleHandlers['viewportRemove']();
+    assert.ok(!('password' in result), 'result must not have a password key');
+    assert.ok(
+      !JSON.stringify(result).includes('hunter2'),
+      'result must not contain the admin password anywhere',
+    );
+  });
+
+  test('viewer not found: still clears identity + disables mode → {ok:true, removed:false}', async () => {
+    adminApiMock.findViewerByMac = async () => null;
+    const result = await handleHandlers['viewportRemove']();
+    assert.equal(result.ok, true);
+    assert.equal(result.removed, false);
+    assert.match(result.message, /no matching device found/i);
+    assert.equal(deleteCalls.length, 0, 'deleteViewer must not be called without a row');
+    assert.equal(fsRmCalls.length, 1, 'identity must still be cleared');
+    assert.equal(mockStoreInstance.get('viewport').enabled, false, 'mode must still be disabled');
+  });
+
+  test('login failure: {ok:false}, identity NOT cleared, mode NOT disabled (retry stays possible)', async () => {
+    adminApiMock.login = async () => {
+      throw new Error('login HTTP 401');
+    };
+    const result = await handleHandlers['viewportRemove']();
+    assert.equal(result.ok, false);
+    assert.match(result.message, /could not reach the console/i);
+    assert.equal(fsRmCalls.length, 0, 'identity must NOT be cleared on login failure');
+    assert.equal(
+      mockStoreInstance.get('viewport').enabled,
+      true,
+      'viewport mode must stay enabled so the user can retry',
+    );
+  });
+
+  test('login failure: result carries no secret', async () => {
+    adminApiMock.login = async () => {
+      throw new Error('connect ECONNREFUSED 192.168.1.10:443');
+    };
+    const result = await handleHandlers['viewportRemove']();
+    assert.equal(result.ok, false);
+    assert.ok(!JSON.stringify(result).includes('hunter2'));
+  });
+
+  test('console unreachable mid-delete (deleteViewer rejects): {ok:false}, identity intact', async () => {
+    adminApiMock.deleteViewer = async () => {
+      throw new Error('socket hang up');
+    };
+    const result = await handleHandlers['viewportRemove']();
+    assert.equal(result.ok, false);
+    assert.equal(fsRmCalls.length, 0);
+    assert.equal(mockStoreInstance.get('viewport').enabled, true);
+  });
+
+  test('viewer found but delete rejected (deleteViewer resolves false): {ok:false}, identity intact, mode stays enabled', async () => {
+    adminApiMock.deleteViewer = async (url, cookie, id, dep) => {
+      deleteCalls.push({ url, cookie, id, dep });
+      return false; // non-2xx that did not throw, e.g. 403/500
+    };
+    const result = await handleHandlers['viewportRemove']();
+    assert.equal(result.ok, false, 'a rejected delete must NOT be reported as success');
+    assert.match(result.message, /refused to delete/i);
+    assert.equal(deleteCalls.length, 1, 'the delete WAS attempted');
+    assert.equal(
+      fsRmCalls.length,
+      0,
+      'identity must NOT be wiped — the row still exists on the console',
+    );
+    assert.equal(
+      mockStoreInstance.get('viewport').enabled,
+      true,
+      'viewport mode must stay enabled so a retry can find the same row by MAC',
+    );
+  });
+
+  test('not configured (missing url/username/password): {ok:false}, nothing touched', async () => {
+    mockStoreInstance.set('viewport', {
+      enabled: false,
+      name: '',
+      url: '',
+      username: '',
+      password: '',
+      fallbackProfileId: null,
+    });
+    const result = await handleHandlers['viewportRemove']();
+    assert.equal(result.ok, false);
+    assert.match(result.message, /not configured/i);
+    assert.equal(loginCalls.length, 0, 'must not attempt a login');
+    assert.equal(fsRmCalls.length, 0);
+    assert.equal(mockStoreInstance.get('viewport').enabled, false);
   });
 });
 

--- a/test/main/ipc.test.js
+++ b/test/main/ipc.test.js
@@ -284,6 +284,7 @@ describe('ipc.js – registerIpcHandlers registers exact channel set', () => {
       'startupSettingsGet',
       'viewportConfigGet',
       'viewportRemove',
+      'viewportSharedViewsStatus',
     ];
     assert.deepStrictEqual(Object.keys(handleHandlers).sort(), expectedHandleChannels);
   });

--- a/test/main/render-session.test.js
+++ b/test/main/render-session.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * @file test/main/render-session.test.js
+ * @description Unit tests for the tiny process-memory render-session override
+ * module (2c fix, whole-branch review finding I1). Pure module — no
+ * Electron/Node I/O, no mocking needed — but state is a module-level
+ * singleton, so every test resets it explicitly (beforeEach/afterEach) to
+ * stay isolated from the other test files that share this same require-cache
+ * instance (ipc.test.js, window-viewport-mode.test.js).
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const renderSession = require('../../src/main/render-session');
+
+describe('render-session.js', () => {
+  beforeEach(() => renderSession.clear());
+  afterEach(() => renderSession.clear());
+
+  test('module boundary: exports exactly the three functions', () => {
+    assert.deepStrictEqual(Object.keys(renderSession).sort(), [
+      'clear',
+      'getRenderCredentialOverride',
+      'setRenderCredentialOverride',
+    ]);
+  });
+
+  test('default state: no override set → returns null', () => {
+    assert.strictEqual(renderSession.getRenderCredentialOverride(), null);
+  });
+
+  test('setRenderCredentialOverride then get → returns the same url/username/password', () => {
+    renderSession.setRenderCredentialOverride({
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+    assert.deepEqual(renderSession.getRenderCredentialOverride(), {
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+  });
+
+  test('only url/username/password are retained (extra profile fields like id/name are dropped)', () => {
+    renderSession.setRenderCredentialOverride({
+      id: 'fb',
+      name: 'Fallback',
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+      extra: 'should not survive',
+    });
+    const result = renderSession.getRenderCredentialOverride();
+    assert.deepStrictEqual(Object.keys(result).sort(), ['password', 'url', 'username']);
+  });
+
+  test('username/password omitted on the input → become undefined, not dropped/thrown', () => {
+    renderSession.setRenderCredentialOverride({ url: 'https://fallback.local' });
+    const result = renderSession.getRenderCredentialOverride();
+    assert.strictEqual(result.url, 'https://fallback.local');
+    assert.strictEqual(result.username, undefined);
+    assert.strictEqual(result.password, undefined);
+  });
+
+  test('clear() resets to null', () => {
+    renderSession.setRenderCredentialOverride({ url: 'https://fallback.local' });
+    renderSession.clear();
+    assert.strictEqual(renderSession.getRenderCredentialOverride(), null);
+  });
+
+  test('clear() is a no-op (does not throw) when nothing was set', () => {
+    assert.doesNotThrow(() => renderSession.clear());
+    assert.strictEqual(renderSession.getRenderCredentialOverride(), null);
+  });
+
+  test('setRenderCredentialOverride(null) clears any existing override', () => {
+    renderSession.setRenderCredentialOverride({ url: 'https://fallback.local' });
+    renderSession.setRenderCredentialOverride(null);
+    assert.strictEqual(renderSession.getRenderCredentialOverride(), null);
+  });
+
+  test('setting a new override replaces the previous one entirely', () => {
+    renderSession.setRenderCredentialOverride({ url: 'https://first.local', username: 'a' });
+    renderSession.setRenderCredentialOverride({ url: 'https://second.local', username: 'b' });
+    assert.deepEqual(renderSession.getRenderCredentialOverride(), {
+      url: 'https://second.local',
+      username: 'b',
+      password: undefined,
+    });
+  });
+});

--- a/test/main/secure.test.js
+++ b/test/main/secure.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * @file test/main/secure.test.js
+ * @description Behavioral contract tests for src/main/secure.js.
+ * No real Electron: a fake safeStorage is injected via the `deps` parameter,
+ * so these tests run under plain Node 22.
+ */
+
+const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const secure = require('../../src/main/secure');
+
+// ── Fake safeStorage ─────────────────────────────────────────────────────────
+// encryptString: prepends 'X' and returns a Buffer; decryptString reverses it.
+// Distinct from base64 so tests can prove both transforms were applied.
+function makeFakeSafeStorage({ available = true } = {}) {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (s) => Buffer.from('X' + s, 'utf8'),
+    decryptString: (buf) => {
+      const s = buf.toString('utf8');
+      if (!s.startsWith('X')) throw new Error('bad ciphertext');
+      return s.slice(1);
+    },
+  };
+}
+
+let warnings;
+let deps;
+
+describe('secure.js – encryptSecret / decryptSecret', () => {
+  beforeEach(() => {
+    warnings = [];
+    deps = { safeStorage: makeFakeSafeStorage(), warn: (m) => warnings.push(m) };
+  });
+
+  test('module exports exactly the expected symbols', () => {
+    assert.deepStrictEqual(
+      Object.keys(secure).sort(),
+      [
+        'ENC_PREFIX',
+        'PLAIN_PREFIX',
+        'decryptSecret',
+        'encryptSecret',
+        'isSecretEncryptionAvailable',
+      ].sort(),
+    );
+    assert.equal(secure.ENC_PREFIX, 'enc:');
+    assert.equal(secure.PLAIN_PREFIX, 'plain:');
+  });
+
+  test('encrypt → enc: prefix + base64 ciphertext when encryption is available', () => {
+    const stored = secure.encryptSecret('hunter2', deps);
+    assert.ok(stored.startsWith('enc:'), `expected enc: prefix, got ${stored}`);
+    const ciphertext = Buffer.from(stored.slice(4), 'base64').toString('utf8');
+    assert.equal(ciphertext, 'Xhunter2'); // fake transform applied, NOT the plaintext
+    assert.equal(warnings.length, 0);
+  });
+
+  test('round-trip: decryptSecret(encryptSecret(x)) === x', () => {
+    assert.equal(secure.decryptSecret(secure.encryptSecret('hunter2', deps), deps), 'hunter2');
+  });
+
+  test('encrypt falls back to plain: prefix and WARNS when encryption unavailable', () => {
+    const noEnc = {
+      safeStorage: makeFakeSafeStorage({ available: false }),
+      warn: (m) => warnings.push(m),
+    };
+    const stored = secure.encryptSecret('hunter2', noEnc);
+    assert.equal(stored, 'plain:hunter2');
+    assert.equal(warnings.length, 1, 'must warn — never silently claim encryption');
+  });
+
+  test('encryptSecret("") returns "" (no prefix, no warn)', () => {
+    assert.equal(secure.encryptSecret('', deps), '');
+    assert.equal(warnings.length, 0);
+  });
+
+  test('decryptSecret routes plain: prefix without touching safeStorage', () => {
+    const noStorage = { safeStorage: null, warn: (m) => warnings.push(m) };
+    assert.equal(secure.decryptSecret('plain:hunter2', noStorage), 'hunter2');
+  });
+
+  test('decryptSecret tolerates a legacy bare string as plaintext', () => {
+    const noStorage = { safeStorage: null, warn: (m) => warnings.push(m) };
+    assert.equal(secure.decryptSecret('hunter2', noStorage), 'hunter2');
+  });
+
+  test('decryptSecret("") and decryptSecret(undefined) return ""', () => {
+    assert.equal(secure.decryptSecret('', deps), '');
+    assert.equal(secure.decryptSecret(undefined, deps), '');
+  });
+
+  test('decryptSecret returns "" and warns when decryption fails', () => {
+    const stored = 'enc:' + Buffer.from('not-our-ciphertext', 'utf8').toString('base64');
+    assert.equal(secure.decryptSecret(stored, deps), '');
+    assert.equal(warnings.length, 1);
+  });
+
+  test('isSecretEncryptionAvailable reflects the injected impl', () => {
+    assert.equal(secure.isSecretEncryptionAvailable(deps), true);
+    assert.equal(
+      secure.isSecretEncryptionAvailable({
+        safeStorage: makeFakeSafeStorage({ available: false }),
+      }),
+      false,
+    );
+  });
+
+  test('isSecretEncryptionAvailable returns false when the impl throws', () => {
+    const throwing = {
+      safeStorage: {
+        isEncryptionAvailable: () => {
+          throw new Error('boom');
+        },
+      },
+    };
+    assert.equal(secure.isSecretEncryptionAvailable(throwing), false);
+  });
+});

--- a/test/main/store.test.js
+++ b/test/main/store.test.js
@@ -32,7 +32,23 @@ let buildConfigContent = null; // null = file does not exist
 
 const originalLoad = Module._load;
 
+// ── Fake secure.js ────────────────────────────────────────────────────────────
+// Deterministic, reversible stand-in so viewport tests can assert both the
+// stored (ciphertext) form and the decrypted form without real Electron.
+const fakeSecure = {
+  available: true,
+  encryptSecret: (s) => (s ? 'enc:' + Buffer.from(s, 'utf8').toString('base64') : ''),
+  decryptSecret: (s) => {
+    if (!s) return '';
+    if (s.startsWith('enc:')) return Buffer.from(s.slice(4), 'base64').toString('utf8');
+    if (s.startsWith('plain:')) return s.slice(6);
+    return s;
+  },
+  isSecretEncryptionAvailable: () => fakeSecure.available,
+};
+
 function installMocks() {
+  fakeSecure.available = true;
   mockStoreInstance = new MockStore();
   mockFsExistsSync = (p) => {
     if (p.endsWith('build-config.json')) return buildConfigContent !== null;
@@ -52,6 +68,7 @@ function installMocks() {
         }
       };
     }
+    if (request === './secure') return fakeSecure;
     if (request === 'node:fs') {
       return {
         existsSync: mockFsExistsSync,
@@ -101,6 +118,8 @@ describe('store.js – module boundary contract', () => {
       'getProfiles',
       'getStartupProfileId',
       'getStartupSettings',
+      'getViewportConfig',
+      'getViewportConfigRedacted',
       'getWindowBounds',
       'hasConfig',
       'isInitialised',
@@ -112,6 +131,7 @@ describe('store.js – module boundary contract', () => {
       'setActiveProfileId',
       'setStartupProfileId',
       'setStartupSettings',
+      'setViewportConfig',
     ].sort();
     assert.deepStrictEqual(Object.keys(store).sort(), expectedExports);
   });
@@ -829,5 +849,162 @@ describe('store.js – getStartupSettings / setStartupSettings', () => {
   test('displayIndex defaults to 0', () => {
     const store = requireFreshStore();
     assert.strictEqual(store.getStartupSettings().displayIndex, 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VIEWPORT CONFIG
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('store.js – viewport config (2c shape)', () => {
+  const DEFAULTS = {
+    enabled: false,
+    name: '',
+    url: '',
+    username: '',
+    password: '',
+    fallbackProfileId: null,
+  };
+
+  beforeEach(() => {
+    buildConfigContent = null;
+    delete process.env.UPV_PORTABLE;
+    installMocks();
+  });
+  afterEach(() => {
+    uninstallMocks();
+    delete require.cache[require.resolve('../../src/main/store')];
+  });
+
+  test('getViewportConfig returns the full default shape when unset', () => {
+    const store = requireFreshStore();
+    assert.deepStrictEqual(store.getViewportConfig(), DEFAULTS);
+  });
+
+  test('setViewportConfig merges partial over existing (Phase-1 callers unaffected)', () => {
+    const store = requireFreshStore();
+    store.setViewportConfig({ enabled: true, name: 'Wall TV' });
+    store.setViewportConfig({ enabled: false });
+    assert.deepStrictEqual(store.getViewportConfig(), {
+      ...DEFAULTS,
+      enabled: false,
+      name: 'Wall TV',
+    });
+  });
+
+  test('setViewportConfig with passwordChanged:true encrypts; getViewportConfig decrypts', () => {
+    const store = requireFreshStore();
+    store.setViewportConfig({
+      enabled: true,
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      passwordChanged: true,
+    });
+    const raw = mockStoreInstance.get('viewport');
+    assert.ok(raw.password.startsWith('enc:'), 'must persist ciphertext, not plaintext');
+    assert.ok(!('passwordChanged' in raw), 'passwordChanged flag must not be persisted');
+    assert.equal(store.getViewportConfig().password, 'hunter2');
+  });
+
+  test('setViewportConfig with passwordChanged falsy RETAINS the stored ciphertext', () => {
+    const store = requireFreshStore();
+    store.setViewportConfig({ password: 'hunter2', passwordChanged: true });
+    const cipherBefore = mockStoreInstance.get('viewport').password;
+    store.setViewportConfig({ url: 'https://nvr2.local', password: 'IGNORED' }); // no flag
+    assert.equal(mockStoreInstance.get('viewport').password, cipherBefore);
+    assert.equal(mockStoreInstance.get('viewport').url, 'https://nvr2.local');
+  });
+
+  test('setViewportConfig passwordChanged:true with empty password clears it', () => {
+    const store = requireFreshStore();
+    store.setViewportConfig({ password: 'hunter2', passwordChanged: true });
+    store.setViewportConfig({ password: '', passwordChanged: true });
+    assert.equal(mockStoreInstance.get('viewport').password, '');
+  });
+
+  test('getViewportConfigRedacted never exposes a password key', () => {
+    const store = requireFreshStore();
+    store.setViewportConfig({
+      enabled: true,
+      name: 'Wall TV',
+      url: 'https://nvr.local',
+      username: 'admin',
+      password: 'hunter2',
+      passwordChanged: true,
+      fallbackProfileId: 'p1',
+    });
+    const red = store.getViewportConfigRedacted();
+    assert.ok(!('password' in red), 'redacted config must not carry the password');
+    assert.equal(red.hasPassword, true);
+    assert.equal(red.enabled, true);
+    assert.equal(red.name, 'Wall TV');
+    assert.equal(red.url, 'https://nvr.local');
+    assert.equal(red.username, 'admin');
+    assert.equal(red.fallbackProfileId, 'p1');
+    assert.equal(red.encryptionAvailable, true);
+    assert.equal(red.defaultName, `${require('node:os').hostname().toUpperCase()}_VIEWPORT`);
+  });
+
+  test('getViewportConfigRedacted: hasPassword=false and encryptionAvailable=false surfaces', () => {
+    fakeSecure.available = false;
+    const store = requireFreshStore();
+    const red = store.getViewportConfigRedacted();
+    assert.equal(red.hasPassword, false);
+    assert.equal(red.encryptionAvailable, false);
+  });
+
+  test('legacy migration: adopt/adoptUser/adoptPass → new shape, keys dropped, url backfilled', () => {
+    mockStoreInstance.set('profiles', [
+      { id: 'p1', name: 'P1', url: 'https://nvr.local/protect', username: 'u', password: 'pw' },
+    ]);
+    mockStoreInstance.set('activeProfileId', 'p1');
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      adopt: true,
+      name: 'CWD Viewport',
+      adoptUser: 'admin',
+      adoptPass: 'onetime',
+    });
+    const store = requireFreshStore();
+    const vp = store.getViewportConfig();
+    assert.deepStrictEqual(vp, {
+      enabled: true,
+      name: 'CWD Viewport',
+      url: 'https://nvr.local/protect', // legacy adopt rode the active profile URL
+      username: 'admin',
+      password: 'onetime', // decrypted on read
+      fallbackProfileId: null,
+    });
+    const raw = mockStoreInstance.get('viewport');
+    assert.ok(raw.password.startsWith('enc:'), 'migrated adoptPass must be encrypted at rest');
+    for (const k of ['adopt', 'adoptUser', 'adoptPass']) {
+      assert.ok(!(k in raw), `legacy key ${k} must be dropped`);
+    }
+  });
+
+  test('legacy migration: adopt:false (poller-era config) migrates without a url', () => {
+    mockStoreInstance.set('viewport', { enabled: true, adopt: false, name: 'Wall TV' });
+    const store = requireFreshStore();
+    assert.deepStrictEqual(store.getViewportConfig(), {
+      ...DEFAULTS,
+      enabled: true,
+      name: 'Wall TV',
+    });
+  });
+
+  test('migration is idempotent (second read does not re-write)', () => {
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      adopt: true,
+      name: 'V',
+      adoptUser: 'a',
+      adoptPass: 'p',
+    });
+    const store = requireFreshStore();
+    store.getViewportConfig();
+    const after = mockStoreInstance.get('viewport');
+    store.getViewportConfig();
+    assert.deepStrictEqual(mockStoreInstance.get('viewport'), after);
   });
 });

--- a/test/main/viewport-adoption-backoff.test.js
+++ b/test/main/viewport-adoption-backoff.test.js
@@ -1,0 +1,17 @@
+'use strict';
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { nextBackoffMs } = require('../../src/main/viewport/adoption/backoff');
+
+describe('adoption backoff', () => {
+  test('grows exponentially from base', () => {
+    assert.equal(nextBackoffMs(0, {}), 1000);
+    assert.equal(nextBackoffMs(1, {}), 2000);
+    assert.equal(nextBackoffMs(2, {}), 4000);
+    assert.equal(nextBackoffMs(3, {}), 8000);
+  });
+  test('caps at maxMs', () => {
+    assert.equal(nextBackoffMs(10, {}), 10000);
+    assert.equal(nextBackoffMs(4, { maxMs: 5000 }), 5000);
+  });
+});

--- a/test/main/viewport-adoption-client.test.js
+++ b/test/main/viewport-adoption-client.test.js
@@ -1,0 +1,323 @@
+'use strict';
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { AdoptionClient } = require('../../src/main/viewport/adoption');
+
+let dir;
+before(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-cl-'));
+});
+after(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+const tick = () => new Promise((r) => setImmediate(r));
+
+function fakeConn() {
+  const c = new EventEmitter();
+  c.open = async () => {};
+  c.stop = () => {
+    c.stopped = true;
+  };
+  return c;
+}
+
+describe('AdoptionClient', () => {
+  test('mints a token (creds present), re-emits online/adopted/assignment as objects', async () => {
+    const conn = fakeConn();
+    const client = new AdoptionClient();
+    let mintedWith = null;
+    const seen = [];
+    client.on('online', (v) => seen.push(['online', v]));
+    client.on('adopted', (a) => seen.push(['adopted', a]));
+    client.on('assignment', (a) => seen.push(['assignment', a]));
+    await client.start({
+      url: 'https://nvr',
+      username: 'admin',
+      password: 'pw',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async (c) => {
+        mintedWith = c;
+        return { token: 'TOKEN', cookie: 'TOKEN=abc' };
+      },
+      connectionFactory: () => conn,
+    });
+    assert.equal(mintedWith.username, 'admin');
+    conn.emit('online');
+    conn.emit('assignment', { liveviewId: 'lv3', liveview: { id: 'lv3' } });
+    await tick();
+    assert.deepEqual(seen, [
+      ['online', true],
+      ['adopted', { viewerId: null }],
+      ['assignment', { liveviewId: 'lv3', liveview: { id: 'lv3' } }],
+    ]);
+    client.stop();
+    assert.ok(conn.stopped);
+  });
+
+  test('keyless: no creds -> does NOT mint a token', async () => {
+    const conn = fakeConn();
+    const client = new AdoptionClient();
+    let minted = false;
+    await client.start({
+      url: 'https://nvr',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async () => {
+        minted = true;
+        return { token: 'X', cookie: 'TOKEN=x' };
+      },
+      connectionFactory: (opts) => {
+        assert.equal(opts.token, null); // keyless connect
+        return conn;
+      },
+    });
+    assert.equal(minted, false);
+  });
+
+  test('emits error when token minting fails, does not throw', async () => {
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start({
+      url: 'https://nvr',
+      username: 'admin',
+      password: 'bad',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async () => {
+        throw new Error('login 401');
+      },
+      connectionFactory: () => {
+        throw new Error('should not reach');
+      },
+    });
+    assert.equal(errs.length, 1);
+    assert.match(errs[0].message, /401/);
+  });
+
+  test('passes through fatal errors from the connection', async () => {
+    const conn = fakeConn();
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start({
+      url: 'https://nvr',
+      deviceName: 'TV',
+      dataDir: dir,
+      connectionFactory: () => conn,
+    });
+    const fatal = new Error('fatal UCP upgrade rejected: HTTP 403');
+    fatal.fatal = true;
+    conn.emit('error', fatal);
+    await tick();
+    assert.equal(errs[0].fatal, true);
+    assert.match(errs[0].message, /403/);
+  });
+
+  test('creds present: mintFn is called once and the minted token is passed to connectionFactory', async () => {
+    const conn = fakeConn();
+    const client = new AdoptionClient();
+    let mintCalls = 0;
+    let seenToken;
+    await client.start({
+      url: 'https://nvr',
+      username: 'admin',
+      password: 'pw',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async () => {
+        mintCalls += 1;
+        return { token: 'MINTED-TOKEN', cookie: 'TOKEN=abc' };
+      },
+      connectionFactory: (opts) => {
+        seenToken = opts.token;
+        return conn;
+      },
+    });
+    assert.equal(mintCalls, 1);
+    assert.equal(seenToken, 'MINTED-TOKEN');
+  });
+
+  test('stop() is idempotent and null-safe', async () => {
+    const client = new AdoptionClient();
+    // Calling stop() before start() must not throw.
+    assert.doesNotThrow(() => client.stop());
+
+    const conn = fakeConn();
+    let stopCalls = 0;
+    const origStop = conn.stop;
+    conn.stop = () => {
+      stopCalls += 1;
+      origStop();
+    };
+    await client.start({
+      url: 'https://nvr',
+      deviceName: 'TV',
+      dataDir: dir,
+      connectionFactory: () => conn,
+    });
+    assert.doesNotThrow(() => client.stop());
+    assert.doesNotThrow(() => client.stop()); // repeat call after already stopped
+    assert.equal(stopCalls, 1);
+  });
+
+  test('C1: derives the ds ws URL (wss://host:7442/viewer/1.0/ws) for the connection factory, from an https profile URL', async () => {
+    const conn = fakeConn();
+    const client = new AdoptionClient();
+    let factoryOpts = null;
+    await client.start({
+      url: 'https://192.168.50.1/protect',
+      deviceName: 'TV',
+      dataDir: dir,
+      connectionFactory: (opts) => {
+        factoryOpts = opts;
+        return conn;
+      },
+    });
+    // NOT :443 (the admin/web URL as-is) — the ds daemon that accepts the
+    // adoption connection lives on :7442, a separate service.
+    assert.equal(factoryOpts.url, 'wss://192.168.50.1:7442/viewer/1.0/ws');
+  });
+
+  test('C1: mintToken still receives the original https base URL, untouched by the ds URL derivation', async () => {
+    const conn = fakeConn();
+    const client = new AdoptionClient();
+    let mintedUrl = null;
+    await client.start({
+      url: 'https://192.168.50.1/protect',
+      username: 'admin',
+      password: 'pw',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async (c) => {
+        mintedUrl = c.url;
+        return { token: 'TOKEN', cookie: 'TOKEN=abc' };
+      },
+      connectionFactory: () => conn,
+    });
+    assert.equal(mintedUrl, 'https://192.168.50.1/protect');
+  });
+
+  // ── I#1 (Task 6 review): mint-failure fatal classification ────────────────
+  // Auth failures (bad admin creds) don't self-heal – must surface as fatal
+  // so window.js's fatal path (fallback / surface-to-config) fires instead of
+  // leaving the app stuck on a dead login page. Network/transient mint errors
+  // stay non-fatal – the underlying connection already retries those.
+
+  test('I#1: mint fails with login HTTP 401 (bad creds) -> fatal error', async () => {
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start({
+      url: 'https://nvr',
+      username: 'admin',
+      password: 'wrong',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async () => {
+        throw new Error('login HTTP 401');
+      },
+      connectionFactory: () => {
+        throw new Error('should not reach');
+      },
+    });
+    assert.equal(errs.length, 1);
+    assert.equal(errs[0].fatal, true, 'HTTP 401 on login is an auth failure -> fatal');
+    assert.match(errs[0].message, /login HTTP 401/);
+  });
+
+  test('I#1: mint fails with manage-payload HTTP 403 (bad/expired session) -> fatal error', async () => {
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start({
+      url: 'https://nvr',
+      username: 'admin',
+      password: 'wrong',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async () => {
+        throw new Error('manage-payload HTTP 403');
+      },
+      connectionFactory: () => {
+        throw new Error('should not reach');
+      },
+    });
+    assert.equal(errs.length, 1);
+    assert.equal(errs[0].fatal, true, 'HTTP 403 on manage-payload is an auth failure -> fatal');
+  });
+
+  test('I#1: mint fails with a NETWORK/transient error (ECONNREFUSED) -> NOT fatal (retryable)', async () => {
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start({
+      url: 'https://nvr',
+      username: 'admin',
+      password: 'pw',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async () => {
+        throw new Error('connect ECONNREFUSED 192.168.1.1:443');
+      },
+      connectionFactory: () => {
+        throw new Error('should not reach');
+      },
+    });
+    assert.equal(errs.length, 1);
+    assert.equal(errs[0].fatal, false, 'a network error must stay retryable, not fatal');
+  });
+
+  test('I#1: mint fails with a transient 5xx (login HTTP 500) -> NOT fatal (retryable)', async () => {
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start({
+      url: 'https://nvr',
+      username: 'admin',
+      password: 'pw',
+      deviceName: 'TV',
+      dataDir: dir,
+      mintToken: async () => {
+        throw new Error('login HTTP 500');
+      },
+      connectionFactory: () => {
+        throw new Error('should not reach');
+      },
+    });
+    assert.equal(errs.length, 1);
+    assert.equal(
+      errs[0].fatal,
+      false,
+      'a 5xx is a server-side transient error, not an auth failure',
+    );
+  });
+
+  test('adopted fires exactly once even when online repeats (reconnect)', async () => {
+    const conn = fakeConn();
+    const client = new AdoptionClient();
+    const seen = [];
+    client.on('online', (v) => seen.push(['online', v]));
+    client.on('adopted', (a) => seen.push(['adopted', a]));
+    await client.start({
+      url: 'https://nvr',
+      deviceName: 'TV',
+      dataDir: dir,
+      connectionFactory: () => conn,
+    });
+    conn.emit('online');
+    conn.emit('closed');
+    conn.emit('online'); // simulated reconnect
+    await tick();
+    const onlineTrueEvents = seen.filter(([type, v]) => type === 'online' && v === true);
+    const adoptedEvents = seen.filter(([type]) => type === 'adopted');
+    assert.equal(onlineTrueEvents.length, 2);
+    assert.equal(adoptedEvents.length, 1);
+    assert.deepEqual(adoptedEvents[0][1], { viewerId: null });
+  });
+});

--- a/test/main/viewport-adoption-connection.test.js
+++ b/test/main/viewport-adoption-connection.test.js
@@ -1,0 +1,601 @@
+'use strict';
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { AdoptionConnection } = require('../../src/main/viewport/adoption/connection');
+const P = require('../../src/main/viewport/adoption/protocol');
+const {
+  loadOrCreateIdentity,
+  certFingerprint256,
+} = require('../../src/main/viewport/adoption/identity');
+
+// Fake ws: records raw binary sends; lets the test push server frames.
+// terminate()/close() are the ONLY things that emit 'close' — mirroring
+// real `ws`, where a dead/aborted socket only closes because something
+// (the watchdog, stop(), the fatal path) actively tore it down, never on
+// its own just because 'unexpected-response' or 'error' fired. Tests must
+// not hand-emit 'close' to simulate cleanup; they should assert the
+// connection called terminate()/close() itself.
+class FakeWs extends EventEmitter {
+  constructor() {
+    super();
+    this.sent = [];
+    this.readyState = 1;
+    this.closed = false;
+    this.terminateCalls = 0;
+    this.closeCalls = 0;
+  }
+  send(buf) {
+    this.sent.push(buf);
+  }
+  close() {
+    this.closeCalls++;
+    this.closed = true;
+    this.emit('close');
+  }
+  terminate() {
+    this.terminateCalls++;
+    this.closed = true;
+    this.emit('close');
+  }
+}
+
+const tick = () => new Promise((r) => setImmediate(r));
+
+// Real self-signed identity (loadOrCreateIdentity persists a real PEM cert,
+// so certFingerprint256 — called by connection.js's open() — works).
+let dir;
+let identity;
+before(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-conn-'));
+  identity = loadOrCreateIdentity(dir);
+});
+after(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// One NVR->device request as a two-frame binary message.
+function requestMsg(action, body, id) {
+  return Buffer.concat([
+    P.encodeFrame({ timestamp: 1, type: 'request', action, id }),
+    P.encodeFrame(body || {}),
+  ]);
+}
+
+// A raw (non-JSON) frame, for exercising the malformed-frame path.
+function rawFrame(payload, ver = 1, type = 1) {
+  const head = Buffer.alloc(8);
+  head[0] = ver;
+  head[1] = type;
+  head.writeUIntBE(payload.length, 2, 6);
+  return Buffer.concat([head, payload]);
+}
+
+// localIpFn defaults to a resolved-null fake here (NOT the real
+// P.localIpForHost) so tests stay hermetic — the test fixture's 'nvr'
+// hostname isn't a real address and a genuine dgram/DNS probe against it has
+// no bounded failure mode in a sandboxed/offline environment. Tests that
+// specifically cover the x-ip wiring pass their own localIpFn via `extra`.
+function newConn(fake, extra = {}) {
+  return new AdoptionConnection({
+    url: 'wss://nvr:7442/viewer/1.0/ws',
+    identity,
+    token: 'TKN',
+    name: 'Wall TV',
+    wsFactory: () => fake,
+    nowFn: () => 1000,
+    localIpFn: () => Promise.resolve(null),
+    ...extra,
+  });
+}
+
+describe('AdoptionConnection (UCP core)', () => {
+  test('emits online on open (connection-based)', async () => {
+    const fake = new FakeWs();
+    const conn = newConn(fake);
+    const events = [];
+    conn.on('online', () => events.push('online'));
+    await conn.open();
+    fake.emit('open');
+    assert.deepEqual(events, ['online']);
+  });
+
+  test('open() sends the UCP upgrade header set + cert/key to wsFactory', async () => {
+    const fake = new FakeWs();
+    let capturedUrl;
+    let capturedOpts;
+    const conn = newConn(fake, {
+      wsFactory: (url, opts) => {
+        capturedUrl = url;
+        capturedOpts = opts;
+        return fake;
+      },
+    });
+    await conn.open();
+    assert.equal(capturedUrl, 'wss://nvr:7442/viewer/1.0/ws');
+    assert.equal(capturedOpts.cert, identity.cert);
+    assert.equal(capturedOpts.key, identity.key);
+    assert.deepEqual(capturedOpts.headers, {
+      'sec-websocket-protocol': 'ucp4',
+      'x-ident': identity.mac,
+      'x-type': 'UP Viewport',
+      'x-mode': '0',
+      'x-fingerprint': certFingerprint256(identity),
+      'x-version': '1.4.33',
+      'x-guid': identity.ident,
+      'x-token': 'TKN',
+      'x-adopted': 'true',
+    });
+  });
+
+  test('open() includes x-ip when the injected localIpFn resolves an address', async () => {
+    const fake = new FakeWs();
+    let capturedOpts;
+    let seenHost;
+    const conn = newConn(fake, {
+      wsFactory: (url, opts) => {
+        capturedOpts = opts;
+        return fake;
+      },
+      localIpFn: (host) => {
+        seenHost = host;
+        return Promise.resolve('192.168.50.42');
+      },
+    });
+    await conn.open();
+    assert.equal(seenHost, 'nvr'); // hostname parsed from this._url
+    assert.equal(capturedOpts.headers['x-ip'], '192.168.50.42');
+  });
+
+  test('open() omits x-ip when the injected localIpFn resolves null (connection still opens)', async () => {
+    const fake = new FakeWs();
+    let capturedOpts;
+    const conn = newConn(fake, {
+      wsFactory: (url, opts) => {
+        capturedOpts = opts;
+        return fake;
+      },
+      localIpFn: () => Promise.resolve(null),
+    });
+    const events = [];
+    conn.on('online', () => events.push('online'));
+    await conn.open();
+    assert.equal('x-ip' in capturedOpts.headers, false);
+    fake.emit('open');
+    assert.deepEqual(events, ['online']); // still connects/goes online normally
+  });
+
+  test('open() omits x-ip when the injected localIpFn rejects (failure does not break the connection)', async () => {
+    const fake = new FakeWs();
+    let capturedOpts;
+    const conn = newConn(fake, {
+      wsFactory: (url, opts) => {
+        capturedOpts = opts;
+        return fake;
+      },
+      localIpFn: () => Promise.reject(new Error('probe boom')),
+    });
+    await conn.open();
+    assert.equal('x-ip' in capturedOpts.headers, false);
+  });
+
+  test('open() omits x-token when no token is set', async () => {
+    const fake = new FakeWs();
+    let capturedOpts;
+    const conn = newConn(fake, {
+      token: null,
+      wsFactory: (url, opts) => {
+        capturedOpts = opts;
+        return fake;
+      },
+    });
+    await conn.open();
+    assert.equal('x-token' in capturedOpts.headers, false);
+  });
+
+  test('answers getInfo with a device-info body (two frames, echoed id)', async () => {
+    const fake = new FakeWs();
+    const conn = newConn(fake);
+    await conn.open();
+    fake.emit('open');
+    fake.emit('message', requestMsg('getInfo', {}, 7));
+    await tick();
+    assert.equal(fake.sent.length, 1);
+    const frames = P.parseFrames(fake.sent[0]);
+    const env = JSON.parse(frames[0].payload.toString('utf8'));
+    const body = JSON.parse(frames[1].payload.toString('utf8'));
+    assert.deepEqual(env, { timestamp: 1000, type: 'response', action: 'getInfo', id: 7 });
+    assert.equal(body.mac, identity.mac);
+    assert.equal(body.modelKey, 'viewer');
+  });
+
+  test('acks networkStatus/enableUpdatesChannel with {} and opens NO second socket', async () => {
+    const fake = new FakeWs();
+    let factoryCalls = 0;
+    const conn = newConn(fake, {
+      wsFactory: () => {
+        factoryCalls += 1;
+        return fake;
+      },
+      nowFn: () => 1,
+    });
+    await conn.open();
+    fake.emit('open');
+    fake.emit('message', requestMsg('networkStatus', {}, 1));
+    fake.emit(
+      'message',
+      requestMsg('enableUpdatesChannel', { uri: 'wss://nvr:7442', lastUpdateId: 9 }, 2),
+    );
+    await tick();
+    assert.equal(factoryCalls, 1); // never dials the updates channel
+    for (const buf of fake.sent) {
+      const body = JSON.parse(P.parseFrames(buf)[1].payload.toString('utf8'));
+      assert.deepEqual(body, {});
+    }
+  });
+
+  test('configure emits assignment{liveviewId,liveview} and acks {}', async () => {
+    const fake = new FakeWs();
+    const conn = newConn(fake);
+    const seen = [];
+    conn.on('assignment', (a) => seen.push(a));
+    await conn.open();
+    fake.emit('open');
+    fake.emit('message', requestMsg('configure', { liveview: { id: 'lv9', layout: 5 } }, 3));
+    await tick();
+    assert.deepEqual(seen, [{ liveviewId: 'lv9', liveview: { id: 'lv9', layout: 5 } }]);
+    const body = JSON.parse(P.parseFrames(fake.sent[0])[1].payload.toString('utf8'));
+    assert.deepEqual(body, {});
+  });
+
+  test('configure with no liveview emits assignment(null) (unassign) and acks {}', async () => {
+    const fake = new FakeWs();
+    const conn = newConn(fake);
+    const seen = [];
+    conn.on('assignment', (a) => seen.push(a));
+    await conn.open();
+    fake.emit('open');
+    fake.emit('message', requestMsg('configure', {}, 5));
+    await tick();
+    assert.deepEqual(seen, [null]);
+    const body = JSON.parse(P.parseFrames(fake.sent[0])[1].payload.toString('utf8'));
+    assert.deepEqual(body, {});
+  });
+
+  test('changeUserPassword acks {} and reports passwordNew via onPassword', async () => {
+    const fake = new FakeWs();
+    const pw = [];
+    const conn = newConn(fake, { onPassword: (p) => pw.push(p) });
+    await conn.open();
+    fake.emit('open');
+    fake.emit(
+      'message',
+      requestMsg('changeUserPassword', { username: 'ubnt', passwordOld: 'a', passwordNew: 'b' }, 4),
+    );
+    await tick();
+    assert.deepEqual(pw, ['b']);
+    assert.deepEqual(JSON.parse(P.parseFrames(fake.sent[0])[1].payload.toString('utf8')), {});
+  });
+
+  test('a malformed frame in one message does not desync pairing of the next message', async () => {
+    const fake = new FakeWs();
+    const conn = newConn(fake);
+    const seen = [];
+    conn.on('assignment', (a) => seen.push(a));
+    await conn.open();
+    fake.emit('open');
+    // A message with a valid envelope but a non-JSON body frame: the body
+    // fails JSON.parse and is dropped, leaving an unpaired envelope. If the
+    // decode queue carried across messages (the pre-fix bug), this leftover
+    // envelope would mis-pair against the NEXT message's own envelope/body.
+    const badMsg = Buffer.concat([
+      P.encodeFrame({ timestamp: 1, type: 'request', action: 'configure', id: 40 }),
+      rawFrame(Buffer.from('not-json', 'utf8')),
+    ]);
+    fake.emit('message', badMsg);
+    fake.emit('message', requestMsg('configure', { liveview: { id: 'lv7', layout: 2 } }, 41));
+    await tick();
+    assert.deepEqual(seen, [{ liveviewId: 'lv7', liveview: { id: 'lv7', layout: 2 } }]);
+    assert.equal(fake.sent.length, 1);
+    const env = JSON.parse(P.parseFrames(fake.sent[0])[0].payload.toString('utf8'));
+    assert.equal(env.id, 41);
+  });
+
+  test('stop() closes the socket and blocks further reconnects', async () => {
+    const fake = new FakeWs();
+    const conn = newConn(fake);
+    await conn.open();
+    fake.emit('open');
+    conn.stop();
+    assert.equal(fake.closed, true);
+  });
+
+  test('stop() before open() is a safe no-op', () => {
+    const conn = newConn(new FakeWs());
+    assert.doesNotThrow(() => conn.stop());
+  });
+
+  test('stop() is idempotent when called twice', async () => {
+    const fake = new FakeWs();
+    const conn = newConn(fake);
+    await conn.open();
+    fake.emit('open');
+    conn.stop();
+    assert.doesNotThrow(() => conn.stop());
+    assert.equal(fake.closed, true);
+  });
+});
+
+describe('AdoptionConnection (resilience)', () => {
+  // Controllable timer doubles.
+  function fakeTimers() {
+    const timers = [];
+    const setT = (fn, ms) => {
+      const t = { fn, ms, cleared: false };
+      timers.push(t);
+      return t;
+    };
+    const clearT = (t) => {
+      if (t) t.cleared = true;
+    };
+    const runLast = () => {
+      const t = timers[timers.length - 1];
+      if (t && !t.cleared) t.fn();
+    };
+    return { setT, clearT, timers, runLast };
+  }
+
+  test('reconnects with backoff after an unexpected close, resetting the attempt counter on a successful open', async () => {
+    const ft = fakeTimers();
+    let calls = 0;
+    const sockets = [new FakeWs(), new FakeWs(), new FakeWs()];
+    const seenAttempts = [];
+    const conn = new AdoptionConnection({
+      url: 'wss://nvr:7442/x',
+      identity,
+      token: 'T',
+      name: 'TV',
+      wsFactory: () => sockets[calls++],
+      nowFn: () => 1,
+      backoffFn: (attempt) => {
+        seenAttempts.push(attempt);
+        return (attempt + 1) * 100;
+      },
+      setTimeoutFn: ft.setT,
+      clearTimeoutFn: ft.clearT,
+      localIpFn: () => Promise.resolve(null),
+    });
+    await conn.open(); // dial #1
+    sockets[0].emit('open');
+    sockets[0].emit('close'); // unexpected close -> schedules reconnect at attempt 0
+    let reconnectTimer = ft.timers[ft.timers.length - 1];
+    assert.equal(reconnectTimer.ms, 100); // attempt 0 -> 100ms
+    assert.deepEqual(seenAttempts, [0]);
+    reconnectTimer.fn(); // fire reconnect -> dial #2
+    await tick();
+    assert.equal(calls, 2); // wsFactory called again
+
+    // A SUCCESSFUL open on the reconnect must reset the attempt counter to
+    // 0 — otherwise an occasionally-flaky long-lived link would ratchet its
+    // backoff up forever instead of treating each fresh disconnect as a
+    // first offense. Distinguishing this from "kept incrementing" requires
+    // a SECOND close-then-reconnect cycle and comparing the attempt seen
+    // each time.
+    sockets[1].emit('open');
+    sockets[1].emit('close'); // another unexpected close
+    reconnectTimer = ft.timers[ft.timers.length - 1];
+    assert.deepEqual(seenAttempts, [0, 0]); // attempt 0 again, NOT 1 -> proves the reset
+    assert.equal(reconnectTimer.ms, 100);
+    reconnectTimer.fn(); // fire reconnect -> dial #3
+    await tick();
+    assert.equal(calls, 3);
+  });
+
+  test('read-idle watchdog terminates a silent socket and the resulting close schedules a reconnect', async () => {
+    const ft = fakeTimers();
+    let calls = 0;
+    const sockets = [new FakeWs(), new FakeWs()];
+    const conn = new AdoptionConnection({
+      url: 'wss://nvr:7442/x',
+      identity,
+      token: 'T',
+      name: 'TV',
+      wsFactory: () => sockets[calls++],
+      nowFn: () => 1,
+      idleTimeoutMs: 500,
+      backoffFn: () => 50,
+      setTimeoutFn: ft.setT,
+      clearTimeoutFn: ft.clearT,
+      localIpFn: () => Promise.resolve(null),
+    });
+    await conn.open();
+    sockets[0].emit('open'); // arms the idle timer (timers[0])
+    ft.runLast(); // fire the idle timeout -> terminate()
+    assert.equal(sockets[0].closed, true);
+    // terminate() emits 'close' (as a real dead socket eventually would),
+    // which must drive the SAME unexpected-close reconnect path as any
+    // other unexpected disconnect: a new backoff timer is scheduled.
+    const reconnectTimer = ft.timers[ft.timers.length - 1];
+    assert.equal(reconnectTimer.ms, 50);
+    reconnectTimer.fn();
+    await tick();
+    assert.equal(calls, 2); // wsFactory dialed again after the idle-triggered reconnect
+  });
+
+  test('403 (fp mismatch) is fatal: terminates the leaked socket itself, emits error.fatal, and does NOT reconnect', async () => {
+    // Real `ws` (8.18): once a consumer listens for 'unexpected-response'
+    // (open() does), ws SKIPS its own abortHandshake — so on a real 403/412
+    // NO 'close'/'error' event ever follows on its own; the TCP socket
+    // would leak forever (stuck CONNECTING) unless the connection tears it
+    // down itself. FakeWs mirrors this: only terminate()/close() emit
+    // 'close', so this test proves _failFatal() actually calls
+    // terminate() — it does NOT hand-emit 'close' to simulate cleanup.
+    const ft = fakeTimers();
+    let calls = 0;
+    const fake = new FakeWs();
+    const conn = new AdoptionConnection({
+      url: 'wss://nvr:7442/x',
+      identity,
+      token: 'T',
+      name: 'TV',
+      wsFactory: () => {
+        calls++;
+        return fake;
+      },
+      nowFn: () => 1,
+      setTimeoutFn: ft.setT,
+      clearTimeoutFn: ft.clearT,
+      localIpFn: () => Promise.resolve(null),
+    });
+    const errs = [];
+    conn.on('error', (e) => errs.push(e));
+    await conn.open();
+    fake.emit('unexpected-response', {}, { statusCode: 403 });
+    assert.equal(errs.length, 1);
+    assert.equal(errs[0].fatal, true);
+    assert.equal(fake.terminateCalls, 1); // the connection itself cleaned up the socket
+    assert.equal(fake.closeCalls, 0); // via terminate(), not close()
+    assert.equal(ft.timers.length, 0); // no reconnect scheduled
+    assert.equal(calls, 1);
+  });
+
+  test('drops the token after the first successful open (keyless reconnect)', async () => {
+    // NOTE: adapted from the brief's literal `o.token` shape to the real
+    // wsFactory contract shipped in Task 5 — open() passes {cert, key,
+    // headers}, and the token rides in headers['x-token'] (or is absent).
+    const seenTokens = [];
+    let calls = 0;
+    const sockets = [new FakeWs(), new FakeWs()];
+    const conn = new AdoptionConnection({
+      url: 'wss://nvr:7442/x',
+      identity,
+      token: 'TKN',
+      name: 'TV',
+      wsFactory: (_url, o) => {
+        seenTokens.push(o.headers['x-token'] || null);
+        return sockets[calls++];
+      },
+      nowFn: () => 1,
+      backoffFn: () => 1,
+      setTimeoutFn: (fn) => ({ fn }),
+      clearTimeoutFn: () => {},
+      localIpFn: () => Promise.resolve(null),
+    });
+    await conn.open();
+    sockets[0].emit('open'); // consumes token
+    sockets[0].emit('close');
+    // manually drive the reconnect the fake timer captured
+    await conn.open();
+    assert.equal(seenTokens[0], 'TKN');
+    assert.equal(seenTokens[1], null); // keyless
+  });
+
+  test('stop() cancels a pending reconnect timer; no reconnect fires even if the stale callback runs', async () => {
+    const ft = fakeTimers();
+    let calls = 0;
+    const fake = new FakeWs();
+    const conn = new AdoptionConnection({
+      url: 'wss://nvr:7442/x',
+      identity,
+      token: 'T',
+      name: 'TV',
+      wsFactory: () => {
+        calls++;
+        return fake;
+      },
+      nowFn: () => 1,
+      backoffFn: (n) => (n + 1) * 100,
+      setTimeoutFn: ft.setT,
+      clearTimeoutFn: ft.clearT,
+      localIpFn: () => Promise.resolve(null),
+    });
+    await conn.open();
+    fake.emit('open');
+    fake.emit('close'); // unexpected close -> schedules a reconnect timer
+    const reconnectTimer = ft.timers[ft.timers.length - 1];
+    assert.equal(reconnectTimer.cleared, false);
+    conn.stop();
+    assert.equal(reconnectTimer.cleared, true); // stop() cancelled it
+    // Even if a stale timer callback still fires (e.g. a real timer that
+    // was mid-flight when clearTimeout ran), the internal _stopped guard in
+    // open() must make it a no-op: no second wsFactory call.
+    reconnectTimer.fn();
+    await tick();
+    assert.equal(calls, 1);
+  });
+
+  test("stop() clears an armed idle watchdog directly — not merely inherited from a prior close's cleanup", async () => {
+    // NOTE: _onClose() also clears the idle timer as part of its own
+    // cleanup, so a test that goes open -> close -> stop() would pass this
+    // assertion for the WRONG reason (already cleared before stop() ever
+    // ran). Isolate stop()'s own idle-clear branch by calling it with the
+    // idle timer armed and NO intervening close.
+    const ft = fakeTimers();
+    let calls = 0;
+    const fake = new FakeWs();
+    const conn = new AdoptionConnection({
+      url: 'wss://nvr:7442/x',
+      identity,
+      token: 'T',
+      name: 'TV',
+      wsFactory: () => {
+        calls++;
+        return fake;
+      },
+      nowFn: () => 1,
+      setTimeoutFn: ft.setT,
+      clearTimeoutFn: ft.clearT,
+      localIpFn: () => Promise.resolve(null),
+    });
+    await conn.open();
+    fake.emit('open'); // arms ONLY the idle watchdog
+    assert.equal(ft.timers.length, 1);
+    const idleTimer = ft.timers[0];
+    assert.equal(idleTimer.cleared, false);
+    conn.stop(); // must clear it directly — _onClose never ran
+    assert.equal(idleTimer.cleared, true);
+    // Firing the (cleared) idle callback anyway must not resurrect the
+    // connection: no terminate on a socket stop() already tore down
+    // (stop() nulls this._ws), and no reconnect scheduled.
+    idleTimer.fn();
+    await tick();
+    assert.equal(calls, 1);
+    assert.equal(ft.timers.length, 1); // stop() did not itself schedule anything
+  });
+
+  test('a throwing consumer callback (assignment listener or onPassword) does not abort processing of the remaining pairs in one message', async () => {
+    const fake = new FakeWs();
+    const seenAssign = [];
+    const conn = newConn(fake, {
+      onPassword: () => {
+        throw new Error('onPassword boom');
+      },
+    });
+    conn.on('assignment', (a) => {
+      seenAssign.push(a);
+      if (seenAssign.length === 1) throw new Error('assignment boom');
+    });
+    await conn.open();
+    fake.emit('open');
+    // One WS message carrying THREE request pairs back to back: configure
+    // (assignment listener throws), changeUserPassword (onPassword
+    // throws), configure again. All three must still get acked, and the
+    // second configure's assignment must still be observed.
+    const msg = Buffer.concat([
+      P.encodeFrame({ timestamp: 1, type: 'request', action: 'configure', id: 10 }),
+      P.encodeFrame({ liveview: { id: 'lvA', layout: 1 } }),
+      P.encodeFrame({ timestamp: 1, type: 'request', action: 'changeUserPassword', id: 11 }),
+      P.encodeFrame({ username: 'ubnt', passwordOld: 'a', passwordNew: 'b' }),
+      P.encodeFrame({ timestamp: 1, type: 'request', action: 'configure', id: 12 }),
+      P.encodeFrame({ liveview: { id: 'lvB', layout: 2 } }),
+    ]);
+    fake.emit('message', msg);
+    await tick();
+    assert.equal(seenAssign.length, 2);
+    assert.deepEqual(seenAssign[1], { liveviewId: 'lvB', liveview: { id: 'lvB', layout: 2 } });
+    assert.equal(fake.sent.length, 3); // all three pairs still acked
+  });
+});

--- a/test/main/viewport-adoption-deps.test.js
+++ b/test/main/viewport-adoption-deps.test.js
@@ -1,0 +1,14 @@
+'use strict';
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('adoption deps', () => {
+  test('ws is installed and exposes WebSocket', () => {
+    const WebSocket = require('ws');
+    assert.equal(typeof WebSocket, 'function');
+  });
+  test('selfsigned is installed and exposes generate', () => {
+    const selfsigned = require('selfsigned');
+    assert.equal(typeof selfsigned.generate, 'function');
+  });
+});

--- a/test/main/viewport-adoption-identity.test.js
+++ b/test/main/viewport-adoption-identity.test.js
@@ -1,0 +1,57 @@
+'use strict';
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const process = require('node:process');
+const { loadOrCreateIdentity } = require('../../src/main/viewport/adoption/identity');
+
+let dir;
+before(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-id-'));
+});
+after(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('adoption identity', () => {
+  test('generates a PEM cert + key and a 12-hex mac', () => {
+    const id = loadOrCreateIdentity(dir);
+    assert.match(id.cert, /-----BEGIN CERTIFICATE-----/);
+    assert.match(id.key, /-----BEGIN (RSA )?PRIVATE KEY-----/);
+    assert.match(id.mac, /^[0-9A-F]{12}$/);
+    assert.equal(typeof id.ident, 'string');
+  });
+
+  test('is stable across calls (persisted, not regenerated)', () => {
+    const a = loadOrCreateIdentity(dir);
+    const b = loadOrCreateIdentity(dir);
+    assert.equal(a.cert, b.cert);
+    assert.equal(a.key, b.key);
+    assert.equal(a.mac, b.mac);
+    assert.equal(a.ident, b.ident);
+  });
+
+  test(
+    'persists the private key with 0600 perms (POSIX)',
+    { skip: process.platform === 'win32' },
+    () => {
+      loadOrCreateIdentity(dir);
+      const mode = fs.statSync(path.join(dir, 'device.key.pem')).mode & 0o777;
+      assert.equal(mode, 0o600);
+    },
+  );
+});
+
+const crypto = require('node:crypto');
+const { certFingerprint256 } = require('../../src/main/viewport/adoption/identity');
+
+describe('certFingerprint256', () => {
+  test('returns uppercase colon-hex SHA-256 matching X509Certificate', () => {
+    const id = loadOrCreateIdentity(dir);
+    const fp = certFingerprint256(id);
+    assert.match(fp, /^[0-9A-F]{2}(:[0-9A-F]{2}){31}$/);
+    assert.equal(fp, new crypto.X509Certificate(id.cert).fingerprint256);
+  });
+});

--- a/test/main/viewport-adoption-mint.test.js
+++ b/test/main/viewport-adoption-mint.test.js
@@ -1,0 +1,276 @@
+'use strict';
+const { test, describe, before, after, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const https = require('node:https');
+
+const pinning = require('../../src/main/viewport/adoption/pinning');
+const { loadOrCreateIdentity } = require('../../src/main/viewport/adoption/identity');
+const {
+  mintToken,
+  makeConnection,
+  httpJson,
+  probeAndPinWithTimeout,
+} = require('../../src/main/viewport/adoption/mint');
+
+// I1: pins are keyed by host:port, so :443 (mint) and :7442 (ws) get their OWN
+// pin — deliberately DIFFERENT here so any accidental cross-port reuse would
+// be caught by an equality assertion against the wrong constant.
+const PIN_443 = { fp256: 'AA:BB:443', certPem: 'PINNED-PEM-443' };
+const PIN_7442 = { fp256: 'CC:DD:7442', certPem: 'PINNED-PEM-7442' };
+
+let dir;
+let identity;
+before(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-mint-'));
+  identity = loadOrCreateIdentity(dir);
+  // Pre-pin 'nvr' at BOTH ports so every probeAndPin({host:'nvr',...}) call
+  // below is a cache hit — no real TLS handshake, no real network, anywhere
+  // in this file.
+  pinning.savePin(dir, 'nvr', 443, PIN_443);
+  pinning.savePin(dir, 'nvr', 7442, PIN_7442);
+});
+after(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  mock.restoreAll();
+});
+
+/** Fakes https.request: routes on options.path, replies asynchronously. */
+function fakeRequest(routes) {
+  return (options, callback) => {
+    const req = new EventEmitter();
+    req.write = () => {};
+    req.end = () => {
+      setImmediate(() => {
+        const route = routes[options.path];
+        if (!route) {
+          req.emit('error', new Error(`no fake route for ${options.path}`));
+          return;
+        }
+        const res = new EventEmitter();
+        res.statusCode = route.status;
+        res.headers = route.headers || {};
+        callback(res);
+        if (route.body) res.emit('data', Buffer.from(route.body));
+        res.emit('end');
+      });
+    };
+    return req;
+  };
+}
+
+describe('mint.httpJson', () => {
+  after(() => mock.restoreAll());
+
+  test('uses the pinned TLS options and never rejectUnauthorized:false', async () => {
+    mock.method(
+      https,
+      'request',
+      fakeRequest({ '/x': { status: 200, headers: {}, body: '{"ok":true}' } }),
+    );
+    const res = await httpJson({ url: 'https://nvr/x', method: 'GET' }, { dataDir: dir });
+    assert.equal(res.status, 200);
+    assert.equal(https.request.mock.calls.length, 1);
+    const [options] = https.request.mock.calls[0].arguments;
+    assert.equal(options.rejectUnauthorized, true); // pinned, never false
+    assert.notEqual(options.rejectUnauthorized, false);
+    assert.equal(options.ca, PIN_443.certPem); // :443 pin — never the :7442 one (I1)
+    assert.equal(typeof options.checkServerIdentity, 'function');
+    assert.equal(options.hostname, 'nvr');
+    assert.equal(options.port, 443);
+  });
+});
+
+describe('mint.mintToken', () => {
+  after(() => mock.restoreAll());
+
+  test('performs login -> manage-payload and returns { token, cookie }, pinned throughout', async () => {
+    mock.method(
+      https,
+      'request',
+      fakeRequest({
+        '/api/auth/login': {
+          status: 200,
+          headers: { 'set-cookie': ['TOKEN=abc123; Path=/; HttpOnly'] },
+          body: '',
+        },
+        '/proxy/protect/api/cameras/manage-payload': {
+          status: 200,
+          headers: {},
+          body: JSON.stringify({ mgmt: { token: 'MINTED-TOKEN' } }),
+        },
+      }),
+    );
+    const minted = await mintToken({
+      url: 'https://nvr/',
+      username: 'admin',
+      password: 'pw',
+      dataDir: dir,
+    });
+    assert.equal(minted.token, 'MINTED-TOKEN');
+    // The login session cookie is surfaced so the adopt flow can reuse it
+    // (post-adopt rename) without a second login.
+    assert.equal(minted.cookie, 'TOKEN=abc123');
+    assert.equal(https.request.mock.calls.length, 2);
+    for (const call of https.request.mock.calls) {
+      const [options] = call.arguments;
+      assert.equal(options.rejectUnauthorized, true);
+      assert.notEqual(options.rejectUnauthorized, false);
+      assert.equal(options.ca, PIN_443.certPem); // both login + manage-payload are :443
+    }
+    // manage-payload request carried the session cookie from login.
+    const [mpOptions] = https.request.mock.calls[1].arguments;
+    assert.equal(mpOptions.headers.cookie, 'TOKEN=abc123');
+  });
+
+  test('throws when login does not return HTTP 200', async () => {
+    mock.method(
+      https,
+      'request',
+      fakeRequest({ '/api/auth/login': { status: 401, headers: {}, body: '' } }),
+    );
+    await assert.rejects(
+      () => mintToken({ url: 'https://nvr/', username: 'admin', password: 'wrong', dataDir: dir }),
+      /login HTTP 401/,
+    );
+  });
+});
+
+describe('mint.makeConnection wsFactory', () => {
+  after(() => mock.restoreAll());
+
+  test('merges the given {cert,key,headers} with buildTlsOptions(pin); never rejectUnauthorized:false', async () => {
+    require('ws'); // ensure it's in require.cache before we swap its exports
+    const wsPath = require.resolve('ws');
+    const wsModule = require.cache[wsPath];
+    const OrigWS = wsModule.exports;
+    let captured = null;
+    class StubWS extends EventEmitter {
+      constructor(url, protocols, opts) {
+        super();
+        captured = { url, protocols, opts };
+        this.readyState = 1;
+      }
+      close() {}
+    }
+    wsModule.exports = StubWS;
+    try {
+      const conn = makeConnection({
+        url: 'wss://nvr:7442/x',
+        identity,
+        token: 'TKN',
+        name: 'TV',
+        dataDir: dir,
+      });
+      const headers = {
+        'sec-websocket-protocol': 'ucp4',
+        'x-ident': identity.mac,
+        'x-type': 'UP Viewport',
+        'x-mode': '0',
+        'x-fingerprint': 'FAKE-FP',
+        'x-version': '1.4.33',
+        'x-adopted': 'true',
+        'x-token': 'TKN',
+      };
+      // Drive the async wsFactory the way connection.js's open() does: it
+      // is already given the complete {cert,key,headers} — wsFactory must
+      // not rebuild any of it, only layer pinning on top.
+      await conn._wsFactory('wss://nvr:7442/x', {
+        cert: identity.cert,
+        key: identity.key,
+        headers,
+      });
+      assert.equal(captured.url, 'wss://nvr:7442/x');
+      assert.deepEqual(captured.protocols, []);
+      // Pass-through, untouched by wsFactory.
+      assert.equal(captured.opts.headers, headers);
+      assert.equal(captured.opts.cert, identity.cert);
+      assert.equal(captured.opts.key, identity.key);
+      // Pinned TLS, merged on top — never rejectUnauthorized:false.
+      assert.equal(captured.opts.rejectUnauthorized, true);
+      assert.notEqual(captured.opts.rejectUnauthorized, false);
+      assert.equal(captured.opts.ca, PIN_7442.certPem); // :7442 pin — never the :443 one (I1)
+      assert.equal(typeof captured.opts.checkServerIdentity, 'function');
+    } finally {
+      wsModule.exports = OrigWS;
+    }
+  });
+
+  // I1: on a UDM, :443 (web/admin, behind the UniFi OS reverse proxy) and
+  // :7442 (the `ds` daemon) present DIFFERENT leaf certs. Before the fix,
+  // pinning.js cached one pin per HOST, so this second probeAndPin call (for
+  // :7442) reused the :443 pin instead of probing its own endpoint — which
+  // would make the ds connection's checkServerIdentity fail against the
+  // wrong cert on real hardware. Now pins are keyed by host:port, so each
+  // endpoint gets its OWN pin — and a second call to the SAME host:port
+  // still reuses its cache (no redundant probe).
+  test('probes+pins :443 (mint) and :7442 (ws) on the same host INDEPENDENTLY; a repeat connect to the same host:port reuses its own pin', async () => {
+    mock.method(https, 'request', fakeRequest({ '/x': { status: 200, headers: {}, body: '{}' } }));
+    const probeSpy = mock.method(pinning, 'probeAndPin'); // wraps the real impl ('nvr' pre-pinned in before())
+
+    await httpJson({ url: 'https://nvr/x', method: 'GET' }, { dataDir: dir });
+    await httpJson({ url: 'https://nvr/x', method: 'GET' }, { dataDir: dir }); // repeat :443 call
+
+    require('ws'); // ensure it's in require.cache before we swap its exports
+    const wsPath = require.resolve('ws');
+    const wsModule = require.cache[wsPath];
+    const OrigWS = wsModule.exports;
+    class StubWS extends EventEmitter {
+      constructor() {
+        super();
+        this.readyState = 1;
+      }
+      close() {}
+    }
+    wsModule.exports = StubWS;
+    try {
+      const conn = makeConnection({ url: 'wss://nvr:7442/x', identity, dataDir: dir });
+      await conn._wsFactory('wss://nvr:7442/x', {
+        cert: identity.cert,
+        key: identity.key,
+        headers: {},
+      });
+    } finally {
+      wsModule.exports = OrigWS;
+    }
+
+    assert.equal(probeSpy.mock.calls.length, 3);
+    const [c1] = probeSpy.mock.calls[0].arguments;
+    const [c2] = probeSpy.mock.calls[1].arguments;
+    const [c3] = probeSpy.mock.calls[2].arguments;
+    assert.deepEqual([c1.host, c1.port, c1.dir], ['nvr', 443, dir]);
+    assert.deepEqual([c2.host, c2.port, c2.dir], ['nvr', 443, dir]);
+    assert.deepEqual([c3.host, c3.port, c3.dir], ['nvr', 7442, dir]);
+
+    const [pin1, pin2, pin3] = await Promise.all([
+      probeSpy.mock.calls[0].result,
+      probeSpy.mock.calls[1].result,
+      probeSpy.mock.calls[2].result,
+    ]);
+    assert.deepEqual(pin1, PIN_443);
+    assert.deepEqual(pin2, PIN_443); // same host:port -> reused, not re-probed from scratch
+    assert.deepEqual(pin3, PIN_7442); // different port -> its OWN pin, never the :443 one
+    assert.notDeepEqual(pin3, pin1);
+  });
+});
+
+describe('mint.probeAndPinWithTimeout', () => {
+  after(() => mock.restoreAll());
+
+  test('rejects if the underlying probe never settles within timeoutMs', async () => {
+    mock.method(pinning, 'probeAndPin', () => new Promise(() => {})); // never settles
+    await assert.rejects(
+      () => probeAndPinWithTimeout({ host: 'stuck', port: 443, dir, timeoutMs: 20 }),
+      /timed out/i,
+    );
+  });
+
+  test('resolves normally when the probe settles before the deadline', async () => {
+    mock.method(pinning, 'probeAndPin', async () => PIN_443);
+    const pin = await probeAndPinWithTimeout({ host: 'nvr', port: 443, dir, timeoutMs: 5000 });
+    assert.deepEqual(pin, PIN_443);
+  });
+});

--- a/test/main/viewport-adoption-pinning.test.js
+++ b/test/main/viewport-adoption-pinning.test.js
@@ -1,0 +1,137 @@
+'use strict';
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const P = require('../../src/main/viewport/adoption/pinning');
+
+let dir;
+before(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-pin-'));
+});
+after(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('pinning', () => {
+  test('buildTlsOptions accepts a matching fingerprint, rejects a changed one', () => {
+    const opts = P.buildTlsOptions({ fp256: 'AA:BB', certPem: 'PEM' });
+    assert.equal(opts.rejectUnauthorized, true);
+    assert.equal(opts.ca, 'PEM');
+    assert.equal(opts.checkServerIdentity('nvr', { fingerprint256: 'AA:BB' }), undefined);
+    const err = opts.checkServerIdentity('nvr', { fingerprint256: 'CC:DD' });
+    assert.ok(err instanceof Error);
+    assert.match(err.message, /fingerprint changed/i);
+  });
+
+  test('probeAndPin captures + persists per host:port, reuses cache for the SAME host:port', async () => {
+    let connects = 0;
+    const tlsConnect = (o, onSecure) => {
+      connects += 1;
+      const sock = new EventEmitter();
+      sock.getPeerCertificate = () => ({ fingerprint256: 'AA:BB', raw: Buffer.from('rawcert') });
+      sock.destroy = () => {};
+      setImmediate(onSecure);
+      return sock;
+    };
+    const first = await P.probeAndPin({ host: 'nvr', port: 443, dir, tlsConnect });
+    assert.equal(first.fp256, 'AA:BB');
+    assert.match(first.certPem, /BEGIN CERTIFICATE/);
+    assert.equal(connects, 1);
+    const cached = await P.probeAndPin({ host: 'nvr', port: 443, dir, tlsConnect });
+    assert.equal(cached.fp256, 'AA:BB');
+    assert.equal(connects, 1); // no second TLS probe — same host:port reuses its pin
+    assert.deepEqual(P.loadPins(dir)['nvr:443'], first);
+  });
+
+  // I1: on a UDM, :443 (UniFi OS reverse proxy) and :7442 (ds daemon) present
+  // DIFFERENT leaf certs. A shared host-only pin would make the ds connect's
+  // checkServerIdentity fail against the :443 cert. Pins must be keyed by
+  // host:port so each endpoint is probed and pinned independently.
+  test('probeAndPin pins :443 and :7442 on the SAME host independently — no cross-port reuse', async () => {
+    let connects = 0;
+    const tlsConnect = (o, onSecure) => {
+      connects += 1;
+      const sock = new EventEmitter();
+      // Distinct cert per port, as real UDM hardware presents.
+      sock.getPeerCertificate = () => ({
+        fingerprint256: o.port === 443 ? 'AA:BB:443' : 'CC:DD:7442',
+        raw: Buffer.from(`rawcert-${o.port}`),
+      });
+      sock.destroy = () => {};
+      setImmediate(onSecure);
+      return sock;
+    };
+    const pin443 = await P.probeAndPin({ host: 'udm', port: 443, dir, tlsConnect });
+    const pin7442 = await P.probeAndPin({ host: 'udm', port: 7442, dir, tlsConnect });
+    assert.equal(connects, 2); // each port probed on its own
+    assert.equal(pin443.fp256, 'AA:BB:443');
+    assert.equal(pin7442.fp256, 'CC:DD:7442');
+    assert.notDeepEqual(pin443, pin7442);
+    assert.deepEqual(P.loadPins(dir)['udm:443'], pin443);
+    assert.deepEqual(P.loadPins(dir)['udm:7442'], pin7442);
+    // Re-probing either endpoint now reuses its OWN pin — no growth in connects.
+    const pin443Again = await P.probeAndPin({ host: 'udm', port: 443, dir, tlsConnect });
+    const pin7442Again = await P.probeAndPin({ host: 'udm', port: 7442, dir, tlsConnect });
+    assert.equal(connects, 2);
+    assert.deepEqual(pin443Again, pin443);
+    assert.deepEqual(pin7442Again, pin7442);
+  });
+
+  test('savePin merges multiple host:port keys — a later save does not drop an earlier one', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-pin-multi-'));
+    try {
+      const pinA = { fp256: 'AA:AA', certPem: 'PEM-A' };
+      const pinB = { fp256: 'BB:BB', certPem: 'PEM-B' };
+      const pinC = { fp256: 'CC:CC', certPem: 'PEM-C' };
+      P.savePin(d, 'hostA', 443, pinA);
+      P.savePin(d, 'hostA', 7442, pinB); // same host, different port -> its own key
+      P.savePin(d, 'hostB', 443, pinC);
+      const pins = P.loadPins(d);
+      assert.deepEqual(pins['hostA:443'], pinA);
+      assert.deepEqual(pins['hostA:7442'], pinB);
+      assert.deepEqual(pins['hostB:443'], pinC);
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  test('probeAndPin rejects on a TLS connection error and persists nothing', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-pin-err-'));
+    try {
+      const tlsConnect = () => {
+        const sock = new EventEmitter();
+        sock.getPeerCertificate = () => ({});
+        sock.destroy = () => {};
+        setImmediate(() => sock.emit('error', new Error('ECONNREFUSED')));
+        return sock;
+      };
+      await assert.rejects(() => P.probeAndPin({ host: 'nvr-err', port: 443, dir: d, tlsConnect }));
+      assert.equal(P.loadPins(d)['nvr-err:443'], undefined);
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  test('probeAndPin rejects when the peer certificate is missing/empty and persists nothing', async () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'upv-pin-nocert-'));
+    try {
+      const tlsConnect = (o, onSecure) => {
+        const sock = new EventEmitter();
+        sock.getPeerCertificate = () => ({}); // no fingerprint256, no raw
+        sock.destroy = () => {};
+        setImmediate(onSecure);
+        return sock;
+      };
+      await assert.rejects(
+        () => P.probeAndPin({ host: 'nvr-nocert', port: 443, dir: d, tlsConnect }),
+        /no peer certificate/i,
+      );
+      assert.equal(P.loadPins(d)['nvr-nocert:443'], undefined);
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/main/viewport-adoption-protocol.test.js
+++ b/test/main/viewport-adoption-protocol.test.js
@@ -1,0 +1,238 @@
+'use strict';
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const P = require('../../src/main/viewport/adoption/protocol');
+
+describe('UCP frame codec', () => {
+  test('encodeFrame writes [ver=1][type=1][6B BE len][json]', () => {
+    const buf = P.encodeFrame({ a: 1 });
+    assert.equal(buf[0], 1);
+    assert.equal(buf[1], 1);
+    assert.equal(buf.readUIntBE(2, 6), buf.length - 8);
+    assert.deepEqual(JSON.parse(buf.subarray(8).toString('utf8')), { a: 1 });
+  });
+
+  test('parseFrames round-trips two concatenated frames', () => {
+    const buf = Buffer.concat([P.encodeFrame({ x: 1 }), P.encodeFrame({ y: 2 })]);
+    const frames = P.parseFrames(buf);
+    assert.equal(frames.length, 2);
+    assert.deepEqual(JSON.parse(frames[0].payload.toString('utf8')), { x: 1 });
+    assert.deepEqual(JSON.parse(frames[1].payload.toString('utf8')), { y: 2 });
+  });
+
+  test('parseFrames flags a truncated tail instead of throwing', () => {
+    const full = P.encodeFrame({ big: 'z' });
+    const frames = P.parseFrames(full.subarray(0, full.length - 2));
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].truncated, true);
+    assert.equal(frames[0].len, full.readUIntBE(2, 6));
+  });
+
+  test('pairFrames pairs positionally and returns a remainder', () => {
+    const a = P.pairFrames([{ e: 1 }, { b: 1 }, { e: 2 }, { b: 2 }]);
+    assert.deepEqual(a.pairs, [
+      { envelope: { e: 1 }, body: { b: 1 } },
+      { envelope: { e: 2 }, body: { b: 2 } },
+    ]);
+    assert.deepEqual(a.remainder, []);
+    const b = P.pairFrames([{ e: 1 }, { b: 1 }, { e: 2 }]);
+    assert.deepEqual(b.pairs, [{ envelope: { e: 1 }, body: { b: 1 } }]);
+    assert.deepEqual(b.remainder, [{ e: 2 }]);
+  });
+});
+
+describe('UCP builders', () => {
+  test('buildResponseFrames echoes id/action with type:response', () => {
+    const buf = P.buildResponseFrames(
+      { action: 'getInfo', id: 42, type: 'request' },
+      { ok: 1 },
+      1000,
+    );
+    const frames = P.parseFrames(buf);
+    assert.equal(frames.length, 2);
+    const env = JSON.parse(frames[0].payload.toString('utf8'));
+    const body = JSON.parse(frames[1].payload.toString('utf8'));
+    assert.deepEqual(env, { timestamp: 1000, type: 'response', action: 'getInfo', id: 42 });
+    assert.deepEqual(body, { ok: 1 });
+  });
+
+  test('buildResponseFrames defaults a nullish body to {}', () => {
+    const frames = P.parseFrames(
+      P.buildResponseFrames({ action: 'networkStatus', id: 5 }, null, 7),
+    );
+    assert.deepEqual(JSON.parse(frames[1].payload.toString('utf8')), {});
+  });
+
+  test('buildDeviceInfo is complete + truthful (modelKey viewer, from identity)', () => {
+    const id = { mac: 'AABBCCDDEEFF', ident: 'guid-1', cert: 'x' };
+    const info = P.buildDeviceInfo(id, 'Wall TV', { ip: '10.0.0.5', uptime: 12, isAdopted: true });
+    assert.equal(info.mac, 'AABBCCDDEEFF');
+    assert.equal(info.name, 'Wall TV');
+    assert.equal(info.modelKey, 'viewer');
+    assert.equal(info.model, 'UP Viewport');
+    assert.equal(info.firmwareVersion, '1.4.33');
+    assert.equal(info.hardwareRevision, '1');
+    assert.equal(info.guid, 'guid-1');
+    assert.equal(info.ip, '10.0.0.5');
+    assert.equal(info.uptime, 12);
+    assert.equal(info.isProvisioned, true);
+    assert.equal(info.isAdopted, true);
+  });
+
+  test('parseConfigure reads liveview.id from the OBJECT (not as a string)', () => {
+    const body = {
+      liveview: { name: 'Default', id: '6960302e03b6a203e4000cb7', layout: 5, slots: [] },
+    };
+    const a = P.parseConfigure(body);
+    assert.equal(a.liveviewId, '6960302e03b6a203e4000cb7');
+    assert.equal(a.liveview.layout, 5);
+  });
+
+  test('parseConfigure returns null when liveview is absent (unassign)', () => {
+    assert.equal(P.parseConfigure({ name: 'x' }), null);
+    assert.equal(P.parseConfigure({}), null);
+    assert.equal(P.parseConfigure(null), null);
+  });
+
+  test('replyBodyFor: getInfo -> device info, everything else -> {} ack', () => {
+    const id = { mac: 'AABBCCDDEEFF', ident: 'g', cert: 'x' };
+    const ctx = { identity: id, name: 'TV', deviceInfoOpts: {} };
+    assert.equal(P.replyBodyFor('getInfo', ctx).mac, 'AABBCCDDEEFF');
+    for (const a of [
+      'networkStatus',
+      'configure',
+      'changeUserPassword',
+      'enableUpdatesChannel',
+      'whatever',
+    ]) {
+      assert.deepEqual(P.replyBodyFor(a, ctx), {});
+    }
+  });
+
+  test('buildUpgradeHeaders sets ucp4 + x-* and only includes x-token when present', () => {
+    const h = P.buildUpgradeHeaders({ mac: 'AABBCCDDEEFF', ident: 'g1', fingerprint: 'AA:BB' });
+    assert.equal(h['sec-websocket-protocol'], 'ucp4');
+    assert.equal(h['x-ident'], 'AABBCCDDEEFF');
+    assert.equal(h['x-type'], 'UP Viewport');
+    assert.equal(h['x-mode'], '0');
+    assert.equal(h['x-fingerprint'], 'AA:BB');
+    assert.equal(h['x-version'], '1.4.33');
+    assert.equal(h['x-guid'], 'g1');
+    assert.equal('x-token' in h, false);
+    const h2 = P.buildUpgradeHeaders({ mac: 'M', fingerprint: 'F', token: 'TKN' });
+    assert.equal(h2['x-token'], 'TKN');
+  });
+
+  test('buildUpgradeHeaders sets x-ip when ip is given, omits it otherwise', () => {
+    const withIp = P.buildUpgradeHeaders({ mac: 'M', fingerprint: 'F', ip: '192.168.50.42' });
+    assert.equal(withIp['x-ip'], '192.168.50.42');
+    const withoutIp = P.buildUpgradeHeaders({ mac: 'M', fingerprint: 'F' });
+    assert.equal('x-ip' in withoutIp, false);
+    const emptyIp = P.buildUpgradeHeaders({ mac: 'M', fingerprint: 'F', ip: '' });
+    assert.equal('x-ip' in emptyIp, false);
+  });
+});
+
+describe('localIpForHost (UDP routing probe — no packets sent)', () => {
+  // Fake udp4 socket: an EventEmitter with connect(port,host,cb) -> cb(),
+  // address() -> {address}, close(). Mirrors node:dgram's Socket surface
+  // just enough for localIpForHost's usage.
+  const { EventEmitter } = require('node:events');
+  class FakeSocket extends EventEmitter {
+    constructor(addr) {
+      super();
+      this._addr = addr;
+      this.closed = false;
+    }
+    connect(_port, _host, cb) {
+      cb();
+    }
+    address() {
+      return { address: this._addr };
+    }
+    close() {
+      this.closed = true;
+    }
+  }
+
+  test('resolves the fake socket source address', async () => {
+    const fake = new FakeSocket('192.168.50.42');
+    const ip = await P.localIpForHost('192.168.50.1', { dgramFactory: () => fake });
+    assert.equal(ip, '192.168.50.42');
+    assert.equal(fake.closed, true);
+  });
+
+  test('a socket that errors instead of connecting resolves null', async () => {
+    class ErroringSocket extends EventEmitter {
+      connect() {
+        // Simulate an async connect failure instead of invoking the callback.
+        setImmediate(() => this.emit('error', new Error('boom')));
+      }
+      address() {
+        throw new Error('should not be called');
+      }
+      close() {}
+    }
+    const ip = await P.localIpForHost('192.168.50.1', { dgramFactory: () => new ErroringSocket() });
+    assert.equal(ip, null);
+  });
+
+  test('a socket that never calls back resolves null after timeoutMs', async () => {
+    class HangingSocket extends EventEmitter {
+      connect() {
+        // Never calls back — but a real dgram socket holds a ref'd OS handle
+        // open while connecting, which is what lets localIpForHost's OWN
+        // (deliberately unref'd) fallback timer actually get a chance to
+        // fire. Mirror that with a ref'd keep-alive interval so this test
+        // exercises the timeout path instead of the process/event-loop
+        // exiting early because nothing else is pending.
+        this._keepAlive = setInterval(() => {}, 1e6);
+      }
+      address() {
+        throw new Error('should not be called');
+      }
+      close() {
+        clearInterval(this._keepAlive);
+      }
+    }
+    const ip = await P.localIpForHost('192.168.50.1', {
+      dgramFactory: () => new HangingSocket(),
+      timeoutMs: 10,
+    });
+    assert.equal(ip, null);
+  });
+
+  test('a dgramFactory that throws synchronously resolves null', async () => {
+    const ip = await P.localIpForHost('192.168.50.1', {
+      dgramFactory: () => {
+        throw new Error('no dgram for you');
+      },
+    });
+    assert.equal(ip, null);
+  });
+});
+
+describe('dsWsUrl (ds daemon WebSocket URL derivation — C1)', () => {
+  test('derives wss://<host>:7442/viewer/1.0/ws from an https base URL', () => {
+    assert.equal(P.dsWsUrl('https://192.168.50.1'), 'wss://192.168.50.1:7442/viewer/1.0/ws');
+  });
+
+  test('a non-standard https port in the input is dropped — still yields :7442', () => {
+    assert.equal(P.dsWsUrl('https://nvr.local:8443'), 'wss://nvr.local:7442/viewer/1.0/ws');
+  });
+
+  test('any path/query on the input base URL is dropped, not merged in', () => {
+    assert.equal(P.dsWsUrl('https://nvr.local/protect?x=1'), 'wss://nvr.local:7442/viewer/1.0/ws');
+  });
+
+  test('forces wss: even when given a plain http: base URL', () => {
+    assert.equal(P.dsWsUrl('http://nvr.local'), 'wss://nvr.local:7442/viewer/1.0/ws');
+  });
+
+  test('port and path are overridable', () => {
+    assert.equal(
+      P.dsWsUrl('https://nvr.local', { port: 1234, path: '/x' }),
+      'wss://nvr.local:1234/x',
+    );
+  });
+});

--- a/test/main/viewport-adoption-token.test.js
+++ b/test/main/viewport-adoption-token.test.js
@@ -1,0 +1,30 @@
+'use strict';
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const T = require('../../src/main/viewport/adoption/token');
+
+describe('adoption token', () => {
+  test('login request posts JSON credentials to /api/auth/login', () => {
+    const r = T.buildLoginRequest('https://192.168.50.1', 'admin', 'pw');
+    assert.equal(r.url, 'https://192.168.50.1/api/auth/login');
+    assert.equal(r.method, 'POST');
+    assert.match(r.headers['content-type'] || r.headers['Content-Type'], /application\/json/i);
+    assert.deepEqual(JSON.parse(r.body), { username: 'admin', password: 'pw', rememberMe: false });
+  });
+
+  test('manage-payload url is the protect API path', () => {
+    assert.equal(
+      T.managePayloadUrl('https://192.168.50.1'),
+      'https://192.168.50.1/proxy/protect/api/cameras/manage-payload',
+    );
+  });
+
+  test('parseTokenResponse returns mgmt.token', () => {
+    assert.equal(T.parseTokenResponse({ mgmt: { token: 'ABC' } }), 'ABC');
+  });
+
+  test('parseTokenResponse throws when token missing', () => {
+    assert.throws(() => T.parseTokenResponse({ mgmt: {} }), /token/i);
+    assert.throws(() => T.parseTokenResponse({}), /token/i);
+  });
+});

--- a/test/main/viewport-assignment.test.js
+++ b/test/main/viewport-assignment.test.js
@@ -1,0 +1,62 @@
+'use strict';
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  findViewer,
+  selectLiveviewId,
+  liveviewUrl,
+  assignmentTargetUrl,
+} = require('../../src/main/viewport/assignment');
+
+const bootstrap = {
+  viewers: [
+    { id: 'a1', name: 'Other', liveviewId: 'xxx' },
+    { id: 'b2', name: 'Wall TV', liveviewId: '699e37cc0208bf03e4273775' },
+    { id: 'c3', name: 'Empty', liveviewId: '' },
+  ],
+};
+
+describe('assignment helpers', () => {
+  test('findViewer matches by name', () => {
+    assert.equal(findViewer(bootstrap, 'Wall TV').id, 'b2');
+  });
+  test('findViewer returns null when absent or bootstrap malformed', () => {
+    assert.equal(findViewer(bootstrap, 'Nope'), null);
+    assert.equal(findViewer(null, 'Wall TV'), null);
+    assert.equal(findViewer({}, 'Wall TV'), null);
+  });
+  test('selectLiveviewId returns the assigned id', () => {
+    assert.equal(selectLiveviewId(bootstrap, 'Wall TV'), '699e37cc0208bf03e4273775');
+  });
+  test('selectLiveviewId returns null for empty or missing', () => {
+    assert.equal(selectLiveviewId(bootstrap, 'Empty'), null);
+    assert.equal(selectLiveviewId(bootstrap, 'Nope'), null);
+  });
+  test('selectLiveviewId reads the bootstrap API field name `liveview`', () => {
+    const apiBootstrap = { viewers: [{ name: 'ApiField', liveview: 'lvAPI' }] };
+    assert.equal(selectLiveviewId(apiBootstrap, 'ApiField'), 'lvAPI');
+  });
+  test('selectLiveviewId returns null for empty `liveview` with no liveviewId', () => {
+    const apiBootstrap = { viewers: [{ name: 'ApiEmpty', liveview: '' }] };
+    assert.equal(selectLiveviewId(apiBootstrap, 'ApiEmpty'), null);
+  });
+  test('liveviewUrl builds dashboard URL from origin', () => {
+    assert.equal(
+      liveviewUrl('https://192.168.50.1/protect/dashboard', '699e37cc0208bf03e4273775'),
+      'https://192.168.50.1/protect/dashboard/699e37cc0208bf03e4273775',
+    );
+  });
+  test('liveviewUrl returns null when no liveviewId', () => {
+    assert.equal(liveviewUrl('https://192.168.50.1/x', null), null);
+  });
+  test('assignmentTargetUrl falls back to baseUrl when unassigned', () => {
+    assert.equal(
+      assignmentTargetUrl('https://192.168.50.1/protect/dashboard', null),
+      'https://192.168.50.1/protect/dashboard',
+    );
+    assert.equal(
+      assignmentTargetUrl('https://192.168.50.1/protect/dashboard', 'b2id'),
+      'https://192.168.50.1/protect/dashboard/b2id',
+    );
+  });
+});

--- a/test/main/viewport-bridge.test.js
+++ b/test/main/viewport-bridge.test.js
@@ -1,0 +1,60 @@
+'use strict';
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { ViewportBridge } = require('../../src/main/viewport/bridge');
+
+// Inject a no-op interval so only the immediate first poll runs during tests.
+const noopTimers = { setInterval: () => 1, clearInterval: () => {} };
+const tick = () => new Promise((r) => setImmediate(r));
+
+describe('ViewportBridge', () => {
+  test('emits assignment with liveviewId on first successful poll', async () => {
+    const bootstrap = { viewers: [{ name: 'TV', liveviewId: 'lv1' }] };
+    const bridge = new ViewportBridge({
+      name: 'TV',
+      fetchBootstrap: async () => bootstrap,
+      ...noopTimers,
+    });
+    const seen = [];
+    bridge.on('assignment', (id) => seen.push(id));
+    bridge.start();
+    await tick();
+    assert.deepEqual(seen, ['lv1']);
+  });
+
+  test('does not re-emit assignment when unchanged, re-emits on change', async () => {
+    let current = 'lv1';
+    const bridge = new ViewportBridge({
+      name: 'TV',
+      fetchBootstrap: async () => ({ viewers: [{ name: 'TV', liveviewId: current }] }),
+      ...noopTimers,
+    });
+    const seen = [];
+    bridge.on('assignment', (id) => seen.push(id));
+    bridge.start();
+    await tick();
+    await bridge._poll(); // same value → no emit
+    current = 'lv2';
+    await bridge._poll(); // changed → emit
+    assert.deepEqual(seen, ['lv1', 'lv2']);
+  });
+
+  test('emits status ok:false with message when fetch throws, no assignment', async () => {
+    const bridge = new ViewportBridge({
+      name: 'TV',
+      fetchBootstrap: async () => {
+        throw new Error('HTTP 401');
+      },
+      ...noopTimers,
+    });
+    const statuses = [];
+    const assignments = [];
+    bridge.on('status', (s) => statuses.push(s));
+    bridge.on('assignment', (id) => assignments.push(id));
+    bridge.start();
+    await tick();
+    assert.equal(assignments.length, 0);
+    assert.equal(statuses[0].ok, false);
+    assert.match(statuses[0].error, /401/);
+  });
+});

--- a/test/main/viewport-native.test.js
+++ b/test/main/viewport-native.test.js
@@ -1,0 +1,67 @@
+'use strict';
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { startNativeViewport } = require('../../src/main/viewport/native');
+
+function fakeClient() {
+  const c = new EventEmitter();
+  c.stop = () => {
+    c.stopped = true;
+  };
+  return c;
+}
+
+describe('startNativeViewport', () => {
+  test('navigates to /protect/dashboard/<id> on an assignment', () => {
+    const client = fakeClient();
+    const nav = [];
+    startNativeViewport({ client, baseUrl: 'https://nvr/protect', navigate: (u) => nav.push(u) });
+    client.emit('assignment', { liveviewId: 'lv1', liveview: { id: 'lv1' } });
+    assert.deepEqual(nav, ['https://nvr/protect/dashboard/lv1']);
+  });
+
+  test('navigates to the base url when unassigned (null assignment)', () => {
+    const client = fakeClient();
+    const nav = [];
+    startNativeViewport({ client, baseUrl: 'https://nvr/protect', navigate: (u) => nav.push(u) });
+    client.emit('assignment', null);
+    assert.deepEqual(nav, ['https://nvr/protect']);
+  });
+
+  test('dedupes a repeat of the same target', () => {
+    const client = fakeClient();
+    const nav = [];
+    startNativeViewport({ client, baseUrl: 'https://nvr/protect', navigate: (u) => nav.push(u) });
+    client.emit('assignment', { liveviewId: 'lv1' });
+    client.emit('assignment', { liveviewId: 'lv1' });
+    assert.equal(nav.length, 1);
+  });
+
+  test('stop() stops the client', () => {
+    const client = fakeClient();
+    const handle = startNativeViewport({
+      client,
+      baseUrl: 'https://nvr/protect',
+      navigate: () => {},
+    });
+    handle.stop();
+    assert.equal(client.stopped, true);
+  });
+
+  test('stop() unsubscribes its own listeners from the client (no leak)', () => {
+    const client = fakeClient();
+    const handle = startNativeViewport({
+      client,
+      baseUrl: 'https://nvr/protect',
+      navigate: () => {},
+    });
+    assert.ok(client.listenerCount('assignment') > 0, 'assignment listener should be attached');
+    assert.ok(client.listenerCount('online') > 0, 'online listener should be attached');
+    assert.ok(client.listenerCount('error') > 0, 'error listener should be attached');
+    handle.stop();
+    assert.equal(client.listenerCount('assignment'), 0, 'assignment listener must be removed');
+    assert.equal(client.listenerCount('online'), 0, 'online listener must be removed');
+    assert.equal(client.listenerCount('error'), 0, 'error listener must be removed');
+  });
+});

--- a/test/main/viewport/admin-api.test.js
+++ b/test/main/viewport/admin-api.test.js
@@ -1,0 +1,145 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const api = require('../../../src/main/viewport/adoption/admin-api');
+
+function fakeHttp(routes) {
+  const calls = [];
+  const httpJson = async (reqDesc, opts) => {
+    calls.push({ reqDesc, opts });
+    const key = (reqDesc.method || 'GET') + ' ' + reqDesc.url;
+    const r = routes[key];
+    if (!r) throw new Error('no route ' + key);
+    return typeof r === 'function' ? r(reqDesc, opts) : r;
+  };
+  return { httpJson, calls };
+}
+const buildLoginRequest = (url, u, p) => ({
+  url: url + '/api/auth/login',
+  method: 'POST',
+  body: JSON.stringify({ u, p }),
+});
+
+test('normalizeMac strips colons and uppercases', () => {
+  assert.equal(api.normalizeMac('aa:bb:cc:dd:ee:ff'), 'AABBCCDDEEFF');
+  assert.equal(api.normalizeMac('AABBCCDDEEFF'), 'AABBCCDDEEFF');
+});
+
+test('login returns joined cookie from set-cookie', async () => {
+  const { httpJson } = fakeHttp({
+    'POST https://n/api/auth/login': {
+      status: 200,
+      setCookie: ['TOKEN=x; Path=/', 'JSESSIONID=y; HttpOnly'],
+      body: '',
+    },
+  });
+  const out = await api.login('https://n', 'admin', 'pw', {
+    httpJson,
+    buildLoginRequest,
+    dataDir: '/d',
+  });
+  assert.equal(out.cookie, 'TOKEN=x; JSESSIONID=y');
+});
+
+test('findViewerByMac matches colon/case-insensitively via bootstrap', async () => {
+  const { httpJson } = fakeHttp({
+    'GET https://n/proxy/protect/api/bootstrap': {
+      status: 200,
+      body: JSON.stringify({ viewers: [{ id: '1', mac: 'AABBCCDDEEFF', name: 'X' }] }),
+    },
+  });
+  const v = await api.findViewerByMac('https://n', 'c', 'aa:bb:cc:dd:ee:ff', {
+    httpJson,
+    dataDir: '/d',
+  });
+  assert.equal(v.id, '1');
+  const none = await api.findViewerByMac('https://n', 'c', '001122334455', {
+    httpJson,
+    dataDir: '/d',
+  });
+  assert.equal(none, null);
+});
+
+test('findViewerByMac with an empty mac returns null even when a viewer mac is empty/missing', async () => {
+  const { httpJson } = fakeHttp({
+    'GET https://n/proxy/protect/api/bootstrap': {
+      status: 200,
+      body: JSON.stringify({
+        viewers: [
+          { id: '1', mac: '', name: 'EmptyMac' },
+          { id: '2', name: 'MissingMac' },
+        ],
+      }),
+    },
+  });
+  assert.equal(await api.findViewerByMac('https://n', 'c', '', { httpJson, dataDir: '/d' }), null);
+  assert.equal(
+    await api.findViewerByMac('https://n', 'c', '::--::', { httpJson, dataDir: '/d' }),
+    null,
+    'garbage that normalizes to empty must not match either',
+  );
+});
+
+test('renameViewer PATCHes name and is true only on 200', async () => {
+  const { httpJson, calls } = fakeHttp({
+    'PATCH https://n/proxy/protect/api/viewers/1': { status: 200, body: '{}' },
+  });
+  const ok = await api.renameViewer('https://n', 'c', '1', 'New', { httpJson, dataDir: '/d' });
+  assert.equal(ok, true);
+  assert.deepEqual(JSON.parse(calls[0].reqDesc.body), { name: 'New' });
+});
+
+test('renameViewer false on non-200', async () => {
+  const { httpJson } = fakeHttp({
+    'PATCH https://n/proxy/protect/api/viewers/1': { status: 404, body: '' },
+  });
+  assert.equal(
+    await api.renameViewer('https://n', 'c', '1', 'N', { httpJson, dataDir: '/d' }),
+    false,
+  );
+});
+
+test('deleteViewer true on 200 or 204', async () => {
+  const a = fakeHttp({ 'DELETE https://n/proxy/protect/api/viewers/1': { status: 204, body: '' } });
+  assert.equal(
+    await api.deleteViewer('https://n', 'c', '1', { httpJson: a.httpJson, dataDir: '/d' }),
+    true,
+  );
+  const b = fakeHttp({ 'DELETE https://n/proxy/protect/api/viewers/2': { status: 500, body: '' } });
+  assert.equal(
+    await api.deleteViewer('https://n', 'c', '2', { httpJson: b.httpJson, dataDir: '/d' }),
+    false,
+  );
+});
+
+test('mutations send X-CSRF-Token from the TOKEN cookie JWT; omit it when absent', async () => {
+  // UniFi OS carries the csrf token in the JWT TOKEN cookie's payload.
+  const jwtCookie = (csrf) =>
+    `TOKEN=hdr.${Buffer.from(JSON.stringify({ csrfToken: csrf })).toString('base64url')}.sig; JSESSIONID=y`;
+
+  const r = fakeHttp({
+    'PATCH https://n/proxy/protect/api/viewers/1': { status: 200, body: '{}' },
+  });
+  await api.renameViewer('https://n', jwtCookie('CSRF123'), '1', 'New', {
+    httpJson: r.httpJson,
+    dataDir: '/d',
+  });
+  assert.equal(r.calls[0].reqDesc.headers['x-csrf-token'], 'CSRF123');
+
+  const d = fakeHttp({ 'DELETE https://n/proxy/protect/api/viewers/1': { status: 200, body: '' } });
+  await api.deleteViewer('https://n', jwtCookie('CSRF999'), '1', {
+    httpJson: d.httpJson,
+    dataDir: '/d',
+  });
+  assert.equal(d.calls[0].reqDesc.headers['x-csrf-token'], 'CSRF999');
+
+  // No TOKEN JWT in the cookie (non-UniFi-OS console) → header omitted, old behavior.
+  const n = fakeHttp({
+    'PATCH https://n/proxy/protect/api/viewers/1': { status: 200, body: '{}' },
+  });
+  await api.renameViewer('https://n', 'SOMEOTHER=z', '1', 'New', {
+    httpJson: n.httpJson,
+    dataDir: '/d',
+  });
+  assert.equal(n.calls[0].reqDesc.headers['x-csrf-token'], undefined);
+});

--- a/test/main/viewport/admin-api.test.js
+++ b/test/main/viewport/admin-api.test.js
@@ -112,6 +112,123 @@ test('deleteViewer true on 200 or 204', async () => {
   );
 });
 
+test('getSelf returns the parsed user on 200, null on non-200', async () => {
+  const ok = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': {
+      status: 200,
+      body: JSON.stringify({ id: 'u1', settings: { web: { 'liveview.includeGlobal': true } } }),
+    },
+  });
+  const u = await api.getSelf('https://n', 'c', { httpJson: ok.httpJson, dataDir: '/d' });
+  assert.equal(u.id, 'u1');
+  const bad = fakeHttp({ 'GET https://n/proxy/protect/api/users/self': { status: 403, body: '' } });
+  assert.equal(
+    await api.getSelf('https://n', 'c', { httpJson: bad.httpJson, dataDir: '/d' }),
+    null,
+  );
+});
+
+test('ensureIncludeGlobal SKIPS the PATCH when the flag is already true', async () => {
+  const { httpJson, calls } = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': {
+      status: 200,
+      body: JSON.stringify({ id: 'u1', settings: { web: { 'liveview.includeGlobal': true } } }),
+    },
+  });
+  const r = await api.ensureIncludeGlobal('https://n', 'c', { httpJson, dataDir: '/d' });
+  assert.deepEqual(r, { ok: true, changed: false });
+  assert.equal(calls.length, 1, 'must not PATCH when already enabled');
+  assert.equal(calls[0].reqDesc.method || 'GET', 'GET');
+});
+
+test('ensureIncludeGlobal PATCHes when off, sends CSRF, and PRESERVES other settings.web keys', async () => {
+  const jwtCookie = `TOKEN=hdr.${Buffer.from(JSON.stringify({ csrfToken: 'CSRF1' })).toString('base64url')}.sig`;
+  const { httpJson, calls } = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': {
+      status: 200,
+      body: JSON.stringify({
+        id: 'u1',
+        settings: {
+          web: {
+            'liveview.includeGlobal': false,
+            'liveview.id': 'keep-me',
+            allCamerasLiveview: { id: 'all' },
+          },
+          other: { foo: 1 },
+        },
+      }),
+    },
+    'PATCH https://n/proxy/protect/api/users/self': { status: 200, body: '{}' },
+  });
+  const r = await api.ensureIncludeGlobal('https://n', jwtCookie, { httpJson, dataDir: '/d' });
+  assert.deepEqual(r, { ok: true, changed: true });
+  const patch = calls.find((c) => c.reqDesc.method === 'PATCH');
+  assert.ok(patch, 'must PATCH when the flag is off');
+  assert.equal(patch.reqDesc.headers['x-csrf-token'], 'CSRF1');
+  const sent = JSON.parse(patch.reqDesc.body).settings;
+  assert.equal(sent.web['liveview.includeGlobal'], true, 'flag flipped on');
+  assert.equal(sent.web['liveview.id'], 'keep-me', 'other web keys preserved');
+  assert.deepEqual(sent.web.allCamerasLiveview, { id: 'all' }, 'allCamerasLiveview preserved');
+  assert.deepEqual(sent.other, { foo: 1 }, 'other settings namespaces preserved');
+});
+
+test('ensureIncludeGlobal treats an absent flag as off and enables it', async () => {
+  const { httpJson, calls } = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': {
+      status: 200,
+      body: JSON.stringify({ id: 'u1', settings: { web: {} } }),
+    },
+    'PATCH https://n/proxy/protect/api/users/self': { status: 200, body: '{}' },
+  });
+  const r = await api.ensureIncludeGlobal('https://n', 'c', { httpJson, dataDir: '/d' });
+  assert.deepEqual(r, { ok: true, changed: true });
+  assert.ok(calls.find((c) => c.reqDesc.method === 'PATCH'));
+});
+
+test('ensureIncludeGlobal returns ok:false reason:read when self is unreadable (no PATCH)', async () => {
+  const { httpJson, calls } = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': { status: 401, body: '' },
+  });
+  const r = await api.ensureIncludeGlobal('https://n', 'c', { httpJson, dataDir: '/d' });
+  assert.deepEqual(r, { ok: false, changed: false, reason: 'read' });
+  assert.equal(calls.length, 1, 'must not PATCH when self is unreadable');
+});
+
+test('ensureIncludeGlobal handles a user with NO settings object (no wipe, no throw)', async () => {
+  const { httpJson, calls } = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': {
+      status: 200,
+      body: JSON.stringify({ id: 'u1' }), // settings entirely absent
+    },
+    'PATCH https://n/proxy/protect/api/users/self': { status: 200, body: '{}' },
+  });
+  const r = await api.ensureIncludeGlobal('https://n', 'c', { httpJson, dataDir: '/d' });
+  assert.deepEqual(r, { ok: true, changed: true });
+  const patch = calls.find((c) => c.reqDesc.method === 'PATCH');
+  assert.deepEqual(JSON.parse(patch.reqDesc.body), {
+    settings: { web: { 'liveview.includeGlobal': true } },
+  });
+});
+
+test('getSelf returns null on a 200 with an unparseable body', async () => {
+  const { httpJson } = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': { status: 200, body: 'not json' },
+  });
+  assert.equal(await api.getSelf('https://n', 'c', { httpJson, dataDir: '/d' }), null);
+});
+
+test('ensureIncludeGlobal returns ok:false reason:patch when the PATCH is rejected', async () => {
+  const { httpJson } = fakeHttp({
+    'GET https://n/proxy/protect/api/users/self': {
+      status: 200,
+      body: JSON.stringify({ settings: { web: { 'liveview.includeGlobal': false } } }),
+    },
+    'PATCH https://n/proxy/protect/api/users/self': { status: 403, body: '' },
+  });
+  const r = await api.ensureIncludeGlobal('https://n', 'c', { httpJson, dataDir: '/d' });
+  assert.deepEqual(r, { ok: false, changed: true, reason: 'patch' });
+});
+
 test('mutations send X-CSRF-Token from the TOKEN cookie JWT; omit it when absent', async () => {
   // UniFi OS carries the csrf token in the JWT TOKEN cookie's payload.
   const jwtCookie = (csrf) =>

--- a/test/main/viewport/adoption-rename.test.js
+++ b/test/main/viewport/adoption-rename.test.js
@@ -1,0 +1,284 @@
+'use strict';
+/**
+ * Task 4 (Phase 3 polish): post-online best-effort rename.
+ * After the initial adopt goes online, AdoptionClient uses the login cookie
+ * captured from mintToken to find the viewer by mac and — only when the
+ * server-side name differs from the configured deviceName — PATCH-renames it.
+ * Keyless reconnects (no cookie) and missing deviceName skip entirely, and a
+ * failing admin API must never break the adoption connection (non-fatal).
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { AdoptionClient } = require('../../../src/main/viewport/adoption');
+
+const tick = () => new Promise((r) => setImmediate(r));
+
+function fakeConn() {
+  const c = new EventEmitter();
+  c.open = async () => {};
+  c.stop = () => {
+    c.stopped = true;
+  };
+  return c;
+}
+
+// Identity is injected (loadIdentity) so no fs access happens; the fake
+// adminApi records its calls for assertions. `opts` is read at CALL time, so
+// latch tests can flip found/renameOk between successive `online` emissions.
+function recordingAdminApi(opts = {}) {
+  const calls = { find: [], rename: [] };
+  return {
+    calls,
+    findViewerByMac: async (url, cookie, mac, dep) => {
+      calls.find.push({ url, cookie, mac, dep });
+      return opts.found === undefined
+        ? { id: '9', mac: 'AABBCCDDEEFF', name: 'UP Viewport' }
+        : opts.found;
+    },
+    renameViewer: async (url, cookie, id, name, dep) => {
+      calls.rename.push({ url, cookie, id, name, dep });
+      if (opts.renameThrows) throw new Error('PATCH boom');
+      return opts.renameOk === undefined ? true : opts.renameOk;
+    },
+  };
+}
+
+function baseOpts(conn, adminApi, overrides = {}) {
+  return {
+    url: 'https://nvr',
+    username: 'admin',
+    password: 'pw',
+    deviceName: 'CWD_VIEWPORT',
+    dataDir: '/d',
+    mintToken: async () => ({ token: 't', cookie: 'ck' }),
+    connectionFactory: () => conn,
+    adminApi,
+    loadIdentity: () => ({ mac: 'AABBCCDDEEFF', cert: 'x', key: 'y' }),
+    ...overrides,
+  };
+}
+
+describe('AdoptionClient post-online rename', () => {
+  test('renames the viewer after online when the server-side name differs', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi(); // found name 'UP Viewport' != 'CWD_VIEWPORT'
+    const client = new AdoptionClient();
+    const renamed = [];
+    client.on('renamed', (r) => renamed.push(r));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 1);
+    // find runs against the ORIGINAL admin https URL (not the :7442 ds URL),
+    // with the mint login cookie and the identity mac.
+    assert.equal(adminApi.calls.find[0].url, 'https://nvr');
+    assert.equal(adminApi.calls.find[0].cookie, 'ck');
+    assert.equal(adminApi.calls.find[0].mac, 'AABBCCDDEEFF');
+    // dep wiring: real pinned httpJson + the profile dataDir.
+    assert.equal(typeof adminApi.calls.find[0].dep.httpJson, 'function');
+    assert.equal(adminApi.calls.find[0].dep.dataDir, '/d');
+    assert.equal(adminApi.calls.rename.length, 1);
+    assert.equal(adminApi.calls.rename[0].id, '9');
+    assert.equal(adminApi.calls.rename[0].name, 'CWD_VIEWPORT');
+    assert.equal(adminApi.calls.rename[0].cookie, 'ck');
+    assert.deepEqual(renamed, [{ ok: true, name: 'CWD_VIEWPORT' }]);
+  });
+
+  test('skips the PATCH when the viewer name already matches deviceName', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi({
+      found: { id: '9', mac: 'AABBCCDDEEFF', name: 'CWD_VIEWPORT' },
+    });
+    const client = new AdoptionClient();
+    const renamed = [];
+    client.on('renamed', (r) => renamed.push(r));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 1);
+    assert.equal(adminApi.calls.rename.length, 0, 'name already correct -> no PATCH');
+    assert.deepEqual(renamed, []);
+  });
+
+  test('viewer not found by mac -> no rename, no error', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi({ found: null });
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.rename.length, 0);
+    assert.deepEqual(errs, []);
+  });
+
+  test('keyless reconnect (no creds -> no cookie): never touches the admin API', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi();
+    const client = new AdoptionClient();
+    await client.start(baseOpts(conn, adminApi, { username: undefined, password: undefined }));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 0, 'no cookie -> rename must be skipped');
+    assert.equal(adminApi.calls.rename.length, 0);
+  });
+
+  test('no deviceName configured: rename is skipped', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi();
+    const client = new AdoptionClient();
+    await client.start(baseOpts(conn, adminApi, { deviceName: undefined }));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 0);
+    assert.equal(adminApi.calls.rename.length, 0);
+  });
+
+  test('a throwing admin API is NON-FATAL: start resolved, connection stays, error has fatal:false', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi({ renameThrows: true });
+    const client = new AdoptionClient();
+    const errs = [];
+    const seen = [];
+    client.on('error', (e) => errs.push(e));
+    client.on('online', (v) => seen.push(['online', v]));
+    client.on('adopted', (a) => seen.push(['adopted', a]));
+    await client.start(baseOpts(conn, adminApi)); // must not reject
+    conn.emit('online');
+    await tick();
+    // Rename failed, but adoption itself is untouched.
+    assert.deepEqual(seen, [
+      ['online', true],
+      ['adopted', { viewerId: null }],
+    ]);
+    assert.equal(conn.stopped, undefined, 'connection must NOT be torn down');
+    assert.equal(errs.length, 1);
+    assert.equal(errs[0].fatal, false, 'rename failure is cosmetic -> non-fatal');
+    assert.match(errs[0].message, /rename skipped: PATCH boom/);
+  });
+
+  test('successful rename LATCHES: repeated online events hit the admin API only once', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi(); // 'UP Viewport' != 'CWD_VIEWPORT' -> rename, ok=true
+    const client = new AdoptionClient();
+    const renamed = [];
+    client.on('renamed', (r) => renamed.push(r));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    conn.emit('online'); // in-session reconnects must NOT re-fetch bootstrap
+    await tick();
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 1, 'find (bootstrap fetch) must run once per session');
+    assert.equal(adminApi.calls.rename.length, 1, 'rename must run once per session');
+    assert.deepEqual(renamed, [{ ok: true, name: 'CWD_VIEWPORT' }]);
+  });
+
+  test('already-matching name LATCHES too: no re-find on later online events', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi({
+      found: { id: '9', mac: 'AABBCCDDEEFF', name: 'CWD_VIEWPORT' },
+    });
+    const client = new AdoptionClient();
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    conn.emit('online');
+    await tick();
+    assert.equal(
+      adminApi.calls.find.length,
+      1,
+      'name already correct -> latched after first check',
+    );
+    assert.equal(adminApi.calls.rename.length, 0);
+  });
+
+  test('FAILED rename (renameViewer -> false) does NOT latch: next online retries, then latches on success', async () => {
+    const conn = fakeConn();
+    const opts = { renameOk: false };
+    const adminApi = recordingAdminApi(opts);
+    const client = new AdoptionClient();
+    const renamed = [];
+    client.on('renamed', (r) => renamed.push(r));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 1);
+    assert.equal(adminApi.calls.rename.length, 1);
+    conn.emit('online'); // transient failure -> must retry
+    await tick();
+    assert.equal(adminApi.calls.find.length, 2, 'falsy rename must not latch');
+    assert.equal(adminApi.calls.rename.length, 2);
+    opts.renameOk = true; // server recovers
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.rename.length, 3);
+    conn.emit('online'); // now latched
+    await tick();
+    assert.equal(adminApi.calls.find.length, 3);
+    assert.equal(adminApi.calls.rename.length, 3);
+    assert.deepEqual(renamed, [
+      { ok: false, name: 'CWD_VIEWPORT' },
+      { ok: false, name: 'CWD_VIEWPORT' },
+      { ok: true, name: 'CWD_VIEWPORT' },
+    ]);
+  });
+
+  test('viewer not found does NOT latch: a later online sees the device appear and renames it', async () => {
+    const conn = fakeConn();
+    const opts = { found: null };
+    const adminApi = recordingAdminApi(opts);
+    const client = new AdoptionClient();
+    const renamed = [];
+    client.on('renamed', (r) => renamed.push(r));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 1);
+    assert.equal(adminApi.calls.rename.length, 0);
+    opts.found = { id: '9', mac: 'AABBCCDDEEFF', name: 'UP Viewport' }; // device appears
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 2, 'not-found must not latch');
+    assert.equal(adminApi.calls.rename.length, 1);
+    assert.deepEqual(renamed, [{ ok: true, name: 'CWD_VIEWPORT' }]);
+  });
+
+  test('a THROWN admin API call does NOT latch: next online retries', async () => {
+    const conn = fakeConn();
+    const opts = { renameThrows: true };
+    const adminApi = recordingAdminApi(opts);
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(errs.length, 1);
+    opts.renameThrows = false; // server recovers
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.find.length, 2, 'throw must not latch');
+    assert.equal(adminApi.calls.rename.length, 2);
+  });
+
+  test('findViewerByMac throw is also non-fatal', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi();
+    adminApi.findViewerByMac = async () => {
+      throw new Error('bootstrap 502');
+    };
+    const client = new AdoptionClient();
+    const errs = [];
+    client.on('error', (e) => errs.push(e));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(errs.length, 1);
+    assert.equal(errs[0].fatal, false);
+    assert.match(errs[0].message, /rename skipped: bootstrap 502/);
+  });
+});

--- a/test/main/viewport/adoption-shared-views.test.js
+++ b/test/main/viewport/adoption-shared-views.test.js
@@ -1,0 +1,137 @@
+'use strict';
+/**
+ * Post-online best-effort "Show Shared Multiviews" enforcement.
+ * After the adopt goes online, AdoptionClient reuses the mint login cookie to
+ * call admin-api.ensureIncludeGlobal so the render account can see shared/public
+ * multiviews (else an assigned shared Live View shows as All Cameras). Latches
+ * on success, retries on failure, skips keyless reconnects, and never breaks
+ * adoption. Emits `sharedViews` with the outcome for the settings UI.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { AdoptionClient } = require('../../../src/main/viewport/adoption');
+
+const tick = () => new Promise((r) => setImmediate(r));
+
+function fakeConn() {
+  const c = new EventEmitter();
+  c.open = async () => {};
+  c.stop = () => {
+    c.stopped = true;
+  };
+  return c;
+}
+
+// adminApi with ensureIncludeGlobal recording its calls; result read at CALL
+// time so latch/retry tests can flip it between successive `online` emissions.
+function recordingAdminApi(opts = {}) {
+  const calls = { ensure: [] };
+  return {
+    calls,
+    // rename path is a no-op here (found === name → nothing to do, no latch churn)
+    findViewerByMac: async () => ({ id: '9', mac: 'AABBCCDDEEFF', name: 'CWD_VIEWPORT' }),
+    renameViewer: async () => true,
+    ensureIncludeGlobal: async (url, cookie, dep) => {
+      calls.ensure.push({ url, cookie, dep });
+      if (opts.throws) throw new Error('boom');
+      return opts.result === undefined ? { ok: true, changed: false } : opts.result;
+    },
+  };
+}
+
+function baseOpts(conn, adminApi, overrides = {}) {
+  return {
+    url: 'https://nvr',
+    username: 'admin',
+    password: 'pw',
+    deviceName: 'CWD_VIEWPORT',
+    dataDir: '/d',
+    mintToken: async () => ({ token: 't', cookie: 'ck' }),
+    connectionFactory: () => conn,
+    adminApi,
+    loadIdentity: () => ({ mac: 'AABBCCDDEEFF', cert: 'x', key: 'y' }),
+    ...overrides,
+  };
+}
+
+describe('AdoptionClient post-online shared-views enforcement', () => {
+  test('calls ensureIncludeGlobal after online and emits sharedViews', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi({ result: { ok: true, changed: true } });
+    const client = new AdoptionClient();
+    const events = [];
+    client.on('sharedViews', (r) => events.push(r));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.ensure.length, 1);
+    assert.equal(adminApi.calls.ensure[0].url, 'https://nvr'); // admin https URL, not :7442
+    assert.equal(adminApi.calls.ensure[0].cookie, 'ck'); // mint login cookie
+    assert.equal(typeof adminApi.calls.ensure[0].dep.httpJson, 'function');
+    assert.equal(adminApi.calls.ensure[0].dep.dataDir, '/d');
+    assert.deepEqual(events, [{ ok: true, changed: true }]);
+  });
+
+  test('latches on success — a second online does NOT re-call', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi({ result: { ok: true, changed: false } });
+    const client = new AdoptionClient();
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.ensure.length, 1, 'success latches for the session');
+  });
+
+  test('retries on failure — a later online re-calls until it succeeds', async () => {
+    const conn = fakeConn();
+    const state = { result: { ok: false, reason: 'patch' } };
+    const adminApi = {
+      calls: { ensure: [] },
+      findViewerByMac: async () => ({ id: '9', mac: 'AABBCCDDEEFF', name: 'CWD_VIEWPORT' }),
+      renameViewer: async () => true,
+      ensureIncludeGlobal: async (url, cookie, dep) => {
+        adminApi.calls.ensure.push({ url, cookie, dep });
+        return state.result;
+      },
+    };
+    const client = new AdoptionClient();
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.ensure.length, 1);
+    state.result = { ok: true, changed: true }; // now it works
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.ensure.length, 2, 'failure did not latch — retried');
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.ensure.length, 2, 'now latched after success');
+  });
+
+  test('keyless reconnect (no mint cookie) skips ensureIncludeGlobal', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi();
+    const client = new AdoptionClient();
+    // No username/password -> no mint -> no cookie -> skip.
+    await client.start(baseOpts(conn, adminApi, { username: undefined, password: undefined }));
+    conn.emit('online');
+    await tick();
+    assert.equal(adminApi.calls.ensure.length, 0);
+  });
+
+  test('a throwing ensureIncludeGlobal is non-fatal and emits a failure outcome', async () => {
+    const conn = fakeConn();
+    const adminApi = recordingAdminApi({ throws: true });
+    const client = new AdoptionClient();
+    const events = [];
+    client.on('sharedViews', (r) => events.push(r));
+    await client.start(baseOpts(conn, adminApi));
+    conn.emit('online');
+    await tick();
+    assert.deepEqual(events, [{ ok: false, reason: 'exception' }]);
+    assert.equal(conn.stopped, undefined, 'adoption connection untouched');
+  });
+});

--- a/test/main/window-viewport-gate.test.js
+++ b/test/main/window-viewport-gate.test.js
@@ -1,0 +1,308 @@
+'use strict';
+
+/**
+ * @file test/main/window-viewport-gate.test.js
+ * @description Behavioral contract tests for window.js's Viewport mode gate
+ * inside `startViewportBridge` (adoption vs. Phase-1 poller branch selection,
+ * dataDir/deviceName computation, STRICT fatal-error classification, and
+ * `win.on('closed')` cleanup).
+ *
+ * `startViewportBridge` itself is not exported (only `createMainWindow` is), so
+ * these tests drive it through the real `createMainWindow` → `loadInitialPage`
+ * path, using the SAME `Module._load` mocking pattern window.test.js already
+ * applies to './store'/'./tray'/'./ipc' — extended here with mocks for
+ * './viewport/adoption' and './viewport/bridge' so no real network/filesystem
+ * I/O ever happens. './viewport/native' is left real: it's pure/Electron-free
+ * and already fully unit-tested in viewport-native.test.js, so exercising it
+ * for real here also verifies the two modules wire together correctly.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { Module } = require('node:module');
+const { EventEmitter } = require('node:events');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  installElectronMock,
+  uninstallElectronMock,
+  resetElectronMocks,
+} = require('../helpers/mock-electron');
+
+const MockStore = require('../helpers/mock-store');
+let mockStoreInstance;
+
+const storeApi = {
+  getProfiles: () => mockStoreInstance.get('profiles', []),
+  getStartupProfileId: () => mockStoreInstance.get('startupProfileId'),
+  getStartupSettings: () =>
+    mockStoreInstance.get('startupSettings', {
+      profileId: null,
+      fullscreen: false,
+      displayIndex: 0,
+    }),
+  setActiveProfileId: (id) => mockStoreInstance.set('activeProfileId', id),
+  getWindowBounds: () => mockStoreInstance.get('bounds'),
+  saveWindowBounds: (b) => mockStoreInstance.set('bounds', b),
+  isInitialised: () => mockStoreInstance.has('init'),
+  markInitialised: () => mockStoreInstance.set('init', true),
+  getViewportConfig: () => ({
+    enabled: false,
+    name: '',
+    url: '',
+    username: '',
+    password: '',
+    fallbackProfileId: null,
+    ...mockStoreInstance.get('viewport', {}),
+  }),
+};
+
+const trayMock = { createTray: () => {} };
+const ipcMock = { registerF11Handler: () => {}, currentLogger: () => null };
+
+// ── Mock AdoptionClient: records start()/stop() calls, is a real EventEmitter
+// so tests can drive 'online'/'error' events exactly like the real connection
+// would, without any network/filesystem I/O. ──────────────────────────────────
+let adoptionInstances;
+class MockAdoptionClient extends EventEmitter {
+  constructor() {
+    super();
+    this.startCalls = [];
+    this.stopCalls = 0;
+    adoptionInstances.push(this);
+  }
+  start(conn) {
+    this.startCalls.push(conn);
+    return Promise.resolve();
+  }
+  stop() {
+    this.stopCalls += 1;
+  }
+}
+
+// ── Mock ViewportBridge (Phase-1 poller): just records construction/start/stop
+// so adoption-vs-fallback branch selection is directly observable. ─────────────
+let bridgeInstances;
+class MockViewportBridge extends EventEmitter {
+  constructor(opts) {
+    super();
+    this.opts = opts;
+    this.started = false;
+    this.stopCalls = 0;
+    bridgeInstances.push(this);
+  }
+  start() {
+    this.started = true;
+  }
+  stop() {
+    this.stopCalls += 1;
+  }
+}
+
+const originalLoad = Module._load;
+
+function installMocks() {
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') return require('../helpers/mock-electron').electronMock;
+    if (request === './store') return storeApi;
+    if (request === './tray') return trayMock;
+    if (request === './ipc') return ipcMock;
+    if (request === './viewport/adoption') return { AdoptionClient: MockAdoptionClient };
+    if (request === './viewport/bridge') return { ViewportBridge: MockViewportBridge };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+}
+
+function uninstallMocks() {
+  Module._load = originalLoad;
+}
+
+function requireFreshWindow() {
+  const p = require.resolve('../../src/main/window');
+  delete require.cache[p];
+  return require('../../src/main/window');
+}
+
+function setSingleProfile(url = 'https://nvr.local/protect') {
+  mockStoreInstance.set('profiles', [{ id: 'p1', name: 'P1', url }]);
+}
+
+describe('window.js – Viewport mode gate (adoption vs. Phase-1 poller)', () => {
+  beforeEach(() => {
+    mockStoreInstance = new MockStore();
+    adoptionInstances = [];
+    bridgeInstances = [];
+    resetElectronMocks();
+    installElectronMock();
+    installMocks();
+  });
+
+  afterEach(() => {
+    uninstallMocks();
+    uninstallElectronMock();
+  });
+
+  // ── (a) branch selection ──────────────────────────────────────────────────
+
+  test('dedicated url set starts an AdoptionClient and does NOT start the Phase-1 poller', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    assert.equal(adoptionInstances.length, 1, 'AdoptionClient should be constructed exactly once');
+    assert.equal(bridgeInstances.length, 0, 'ViewportBridge poller should NOT be constructed');
+  });
+
+  test('no dedicated url configured falls back to the Phase-1 poller, not AdoptionClient', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', { enabled: true, name: 'Lobby' }); // no `url` key
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    assert.equal(
+      bridgeInstances.length,
+      1,
+      'ViewportBridge poller should be constructed exactly once',
+    );
+    assert.equal(bridgeInstances[0].started, true, 'poller should be started');
+    assert.equal(adoptionInstances.length, 0, 'AdoptionClient should NOT be constructed');
+  });
+
+  test('viewport disabled entirely: neither AdoptionClient nor the poller is constructed', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: false,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    assert.equal(adoptionInstances.length, 0);
+    assert.equal(bridgeInstances.length, 0);
+  });
+
+  // ── (b) dataDir + deviceName ───────────────────────────────────────────────
+
+  test('adopt: passes dataDir = path.join(userData, "viewport") and the configured deviceName/url to client.start()', async () => {
+    setSingleProfile('https://nvr.local/protect');
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    assert.equal(adoptionInstances.length, 1);
+    const conn = adoptionInstances[0].startCalls[0];
+    assert.equal(conn.dataDir, path.join('/mock/userData', 'viewport'));
+    assert.equal(conn.deviceName, 'Lobby');
+    assert.equal(conn.url, 'https://nvr.local/protect');
+  });
+
+  test('adopt: deviceName falls back to `<HOSTNAME>_VIEWPORT` when vp.name is unset', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', { enabled: true, url: 'https://nvr.local/protect' }); // no name
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const conn = adoptionInstances[0].startCalls[0];
+    assert.equal(conn.deviceName, `${os.hostname().toUpperCase()}_VIEWPORT`);
+  });
+
+  test('adopt: username/password default to undefined when not configured (keyless reconnect path)', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const conn = adoptionInstances[0].startCalls[0];
+    assert.equal(conn.username, undefined);
+    assert.equal(conn.password, undefined);
+  });
+
+  // ── (c) STRICT fatal-error classification ─────────────────────────────────
+
+  test('adopt error: fatal === true stops the client (unrecoverable, surfaced)', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const client = adoptionInstances[0];
+    assert.equal(client.stopCalls, 0);
+    client.emit('error', { message: 'rejected fingerprint: HTTP 403', fatal: true });
+    assert.equal(client.stopCalls, 1, 'fatal === true must stop the client');
+  });
+
+  test('adopt error: fatal === false does NOT stop the client (transient, self-reconnects)', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const client = adoptionInstances[0];
+    client.emit('error', { message: 'transient network blip', fatal: false });
+    assert.equal(client.stopCalls, 0, 'fatal === false must NOT stop the client');
+  });
+
+  test('adopt error: fatal undefined (field absent) does NOT stop the client (transient, self-reconnects)', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const client = adoptionInstances[0];
+    // start()'s own catch-all (e.g. identity load failure) emits {message} only,
+    // with no `fatal` key at all — must not be misclassified as fatal.
+    client.emit('error', { message: 'identity load failed' });
+    assert.equal(client.stopCalls, 0, 'fatal undefined must NOT stop the client');
+  });
+
+  test('adopt error: repeated non-fatal errors never accumulate stop() calls', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const client = adoptionInstances[0];
+    client.emit('error', { message: 'blip 1', fatal: false });
+    client.emit('error', { message: 'blip 2' });
+    client.emit('error', { message: 'blip 3', fatal: false });
+    assert.equal(client.stopCalls, 0);
+  });
+
+  // ── (d) win 'closed' cleanup ───────────────────────────────────────────────
+
+  test('adopt: win "closed" event calls client.stop() for cleanup (no socket/timer leak)', async () => {
+    setSingleProfile();
+    mockStoreInstance.set('viewport', {
+      enabled: true,
+      url: 'https://nvr.local/protect',
+      name: 'Lobby',
+    });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    const client = adoptionInstances[0];
+    assert.equal(client.stopCalls, 0);
+    win.emit('closed');
+    assert.equal(client.stopCalls, 1, 'closed event must stop the AdoptionClient');
+  });
+});

--- a/test/main/window-viewport-mode.test.js
+++ b/test/main/window-viewport-mode.test.js
@@ -254,6 +254,41 @@ describe('window.js – 2c top-level Viewport-mode override', () => {
       win._file && win._file.endsWith('config.html'),
       `expected config.html, got: ${win._file}`,
     );
+    // Non-auth fatal → generic 'failed' reason surfaced to config.html.
+    assert.equal(win._loadFileOpts && win._loadFileOpts.query['vp-error'], 'failed');
+  });
+
+  test('FATAL auth error (bad admin creds) → config.html with vp-error=auth (notify, not silent)', async () => {
+    seedViewport();
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    // mint.js reports bad credentials as `login HTTP 401` (fatal in AdoptionClient).
+    adoptionInstances[0].emit('error', { message: 'login HTTP 401', fatal: true });
+    assert.ok(win._file && win._file.endsWith('config.html'));
+    assert.equal(
+      win._loadFileOpts && win._loadFileOpts.query['vp-error'],
+      'auth',
+      'wrong admin credentials must surface as the auth reason so config.html can explain it',
+    );
+  });
+
+  test('FATAL upgrade rejection (HTTP 403 fingerprint/device rejection) → vp-error=failed, NOT auth', async () => {
+    seedViewport();
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    // connection.js emits this on a ws-upgrade 403 = fingerprint mismatch /
+    // device rejected on the console — NOT a credentials problem, so the user
+    // must NOT be told to re-enter their (correct) password.
+    adoptionInstances[0].emit('error', {
+      message: 'fatal UCP upgrade rejected: HTTP 403',
+      fatal: true,
+    });
+    assert.ok(win._file && win._file.endsWith('config.html'));
+    assert.equal(
+      win._loadFileOpts && win._loadFileOpts.query['vp-error'],
+      'failed',
+      'a device/fingerprint rejection must use the generic reason, not the auth one',
+    );
   });
 
   // ── render-session override (I1 fix) ────────────────────────────────────────

--- a/test/main/window-viewport-mode.test.js
+++ b/test/main/window-viewport-mode.test.js
@@ -1,0 +1,382 @@
+'use strict';
+
+/**
+ * @file test/main/window-viewport-mode.test.js
+ * @description 2c contract tests: loadInitialPage's TOP-LEVEL Viewport-mode
+ * override (beats profile-select/config paths), the dedicated connection fed
+ * to AdoptionClient, and fallback-profile-on-fatal / grace-window behavior.
+ * Same Module._load mock pattern as window-viewport-gate.test.js.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { Module } = require('node:module');
+const { EventEmitter } = require('node:events');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  installElectronMock,
+  uninstallElectronMock,
+  resetElectronMocks,
+} = require('../helpers/mock-electron');
+
+const MockStore = require('../helpers/mock-store');
+let mockStoreInstance;
+
+// render-session.js is intentionally NOT mocked here (no Electron/Node I/O
+// dependency; it's the real singleton window.js writes to) so these tests can
+// observe exactly what ipc.js's onConfigLoad would see in real usage.
+const renderSession = require('../../src/main/render-session');
+
+const VP_DEFAULTS = {
+  enabled: false,
+  name: '',
+  url: '',
+  username: '',
+  password: '',
+  fallbackProfileId: null,
+};
+
+const storeApi = {
+  getProfiles: () => mockStoreInstance.get('profiles', []),
+  getStartupProfileId: () => mockStoreInstance.get('startupProfileId'),
+  getStartupSettings: () =>
+    mockStoreInstance.get('startupSettings', {
+      profileId: null,
+      fullscreen: false,
+      displayIndex: 0,
+    }),
+  setActiveProfileId: (id) => mockStoreInstance.set('activeProfileId', id),
+  getWindowBounds: () => mockStoreInstance.get('bounds'),
+  saveWindowBounds: (b) => mockStoreInstance.set('bounds', b),
+  isInitialised: () => mockStoreInstance.has('init'),
+  markInitialised: () => mockStoreInstance.set('init', true),
+  getViewportConfig: () => ({ ...VP_DEFAULTS, ...mockStoreInstance.get('viewport', {}) }),
+};
+
+const trayMock = { createTray: () => {} };
+const ipcMock = { registerF11Handler: () => {}, currentLogger: () => null };
+
+let adoptionInstances;
+class MockAdoptionClient extends EventEmitter {
+  constructor() {
+    super();
+    this.startCalls = [];
+    this.stopCalls = 0;
+    adoptionInstances.push(this);
+  }
+  start(conn) {
+    this.startCalls.push(conn);
+    return Promise.resolve();
+  }
+  stop() {
+    this.stopCalls += 1;
+  }
+}
+
+let bridgeInstances;
+class MockViewportBridge extends EventEmitter {
+  constructor(opts) {
+    super();
+    this.opts = opts;
+    this.started = false;
+    bridgeInstances.push(this);
+  }
+  start() {
+    this.started = true;
+  }
+  stop() {}
+}
+
+const originalLoad = Module._load;
+function installMocks() {
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') return require('../helpers/mock-electron').electronMock;
+    if (request === './store') return storeApi;
+    if (request === './tray') return trayMock;
+    if (request === './ipc') return ipcMock;
+    if (request === './viewport/adoption') return { AdoptionClient: MockAdoptionClient };
+    if (request === './viewport/bridge') return { ViewportBridge: MockViewportBridge };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+}
+function uninstallMocks() {
+  Module._load = originalLoad;
+}
+function requireFreshWindow() {
+  const p = require.resolve('../../src/main/window');
+  delete require.cache[p];
+  return require('../../src/main/window');
+}
+
+function seedViewport(overrides = {}) {
+  mockStoreInstance.set('viewport', {
+    enabled: true,
+    name: 'Lobby',
+    url: 'https://nvr.local',
+    username: 'admin',
+    password: 'hunter2',
+    fallbackProfileId: null,
+    ...overrides,
+  });
+}
+function seedProfiles(list) {
+  mockStoreInstance.set('profiles', list);
+}
+
+describe('window.js – 2c top-level Viewport-mode override', () => {
+  beforeEach(() => {
+    mockStoreInstance = new MockStore();
+    adoptionInstances = [];
+    bridgeInstances = [];
+    resetElectronMocks();
+    installElectronMock();
+    installMocks();
+    renderSession.clear();
+  });
+  afterEach(() => {
+    renderSession.clear();
+    uninstallMocks();
+    uninstallElectronMock();
+  });
+
+  test('viewport mode beats the profile-select path (multiple profiles, no startup profile)', async () => {
+    seedProfiles([
+      { id: 'a', name: 'A', url: 'https://a.local' },
+      { id: 'b', name: 'B', url: 'https://b.local' },
+    ]);
+    seedViewport();
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    assert.equal(win._url, 'https://nvr.local', 'must load the DEDICATED viewport URL');
+    assert.equal(win._file, null, 'must NOT load profile-select.html');
+    assert.equal(adoptionInstances.length, 1);
+  });
+
+  test('viewport mode works with ZERO profiles (no config.html detour)', async () => {
+    seedProfiles([]);
+    seedViewport();
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    assert.equal(win._url, 'https://nvr.local');
+    assert.equal(win._file, null, 'must NOT load config.html');
+  });
+
+  test('AdoptionClient receives the dedicated connection (url/username/password from viewport config)', async () => {
+    seedProfiles([{ id: 'a', name: 'A', url: 'https://a.local' }]);
+    seedViewport();
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const conn = adoptionInstances[0].startCalls[0];
+    assert.equal(conn.url, 'https://nvr.local');
+    assert.equal(conn.username, 'admin');
+    assert.equal(conn.password, 'hunter2');
+    assert.equal(conn.deviceName, 'Lobby');
+    assert.equal(conn.dataDir, path.join('/mock/userData', 'viewport'));
+  });
+
+  test('empty creds map to undefined (keyless reconnect of a pre-adopted viewer)', async () => {
+    seedViewport({ username: '', password: '' });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    const conn = adoptionInstances[0].startCalls[0];
+    assert.equal(conn.username, undefined);
+    assert.equal(conn.password, undefined);
+  });
+
+  test('empty device name falls back to `<HOSTNAME>_VIEWPORT`', async () => {
+    seedViewport({ name: '' });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    assert.equal(
+      adoptionInstances[0].startCalls[0].deviceName,
+      `${os.hostname().toUpperCase()}_VIEWPORT`,
+    );
+  });
+
+  test('viewport enabled WITHOUT url: profile flow + Phase-1 poller (backwards compatible)', async () => {
+    seedProfiles([{ id: 'a', name: 'A', url: 'https://a.local' }]);
+    seedViewport({ url: '', username: '', password: '' });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    assert.equal(win._url, 'https://a.local', 'single-profile flow unchanged');
+    assert.equal(adoptionInstances.length, 0, 'no AdoptionClient without a dedicated url');
+    assert.equal(bridgeInstances.length, 1, 'Phase-1 poller must still start');
+    assert.equal(bridgeInstances[0].started, true);
+  });
+
+  test('viewport disabled: everything behaves as before (no client, no poller)', async () => {
+    seedProfiles([{ id: 'a', name: 'A', url: 'https://a.local' }]);
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    assert.equal(win._url, 'https://a.local');
+    assert.equal(adoptionInstances.length, 0);
+    assert.equal(bridgeInstances.length, 0);
+  });
+
+  // ── fallback profile ───────────────────────────────────────────────────────
+
+  test('FATAL adoption error + fallback set → loads the fallback profile and activates it', async () => {
+    seedProfiles([{ id: 'fb', name: 'Fallback', url: 'https://fallback.local' }]);
+    seedViewport({ fallbackProfileId: 'fb' });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    adoptionInstances[0].emit('error', { message: 'rejected fingerprint: HTTP 403', fatal: true });
+    assert.equal(win._url, 'https://fallback.local');
+    assert.equal(mockStoreInstance.get('activeProfileId'), 'fb');
+    assert.equal(adoptionInstances[0].stopCalls, 1, 'client must be stopped on fatal');
+  });
+
+  // I#1 (Task 6 review): a fatal error with no USABLE fallback must never
+  // leave the app silently stuck on a dead Protect login page – it surfaces
+  // by navigating to config.html so the user can recover.
+
+  test('FATAL error + STALE fallbackProfileId (no usable fallback) → surfaces via config.html (I#1)', async () => {
+    seedProfiles([{ id: 'other', name: 'O', url: 'https://o.local' }]);
+    seedViewport({ fallbackProfileId: 'deleted-id' });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    adoptionInstances[0].emit('error', { message: 'fatal', fatal: true });
+    assert.ok(
+      win._file && win._file.endsWith('config.html'),
+      `expected config.html, got: ${win._file}`,
+    );
+    assert.equal(adoptionInstances[0].stopCalls, 1, 'client must still be stopped on fatal');
+  });
+
+  test('FATAL error + NO fallback configured → surfaces via config.html (I#1)', async () => {
+    seedViewport();
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    adoptionInstances[0].emit('error', { message: 'fatal', fatal: true });
+    assert.ok(
+      win._file && win._file.endsWith('config.html'),
+      `expected config.html, got: ${win._file}`,
+    );
+  });
+
+  // ── render-session override (I1 fix) ────────────────────────────────────────
+  // The whole-branch review found that after a fallback fires, ipc.js's
+  // onConfigLoad kept returning the viewport connection (its store-side
+  // `enabled`/`url` gate is untouched by a fallback) – so the render session
+  // never actually became the fallback profile. These tests assert window.js
+  // now sets the render-session override to the FALLBACK PROFILE's own
+  // url/username/password, which is what onConfigLoad checks first.
+
+  test('FATAL error + fallback → render-session override becomes the fallback profile (not the viewport connection)', async () => {
+    seedProfiles([
+      {
+        id: 'fb',
+        name: 'Fallback',
+        url: 'https://fallback.local',
+        username: 'fbuser',
+        password: 'fbpass',
+      },
+    ]);
+    seedViewport({ fallbackProfileId: 'fb' });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    assert.equal(
+      renderSession.getRenderCredentialOverride(),
+      null,
+      'no override before fallback fires',
+    );
+    adoptionInstances[0].emit('error', { message: 'rejected fingerprint: HTTP 403', fatal: true });
+    assert.deepEqual(renderSession.getRenderCredentialOverride(), {
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+  });
+
+  test('grace-timeout fallback → render-session override also becomes the fallback profile', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    seedProfiles([
+      {
+        id: 'fb',
+        name: 'Fallback',
+        url: 'https://fallback.local',
+        username: 'fbuser',
+        password: 'fbpass',
+      },
+    ]);
+    seedViewport({ fallbackProfileId: 'fb' });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(renderSession.getRenderCredentialOverride(), {
+      url: 'https://fallback.local',
+      username: 'fbuser',
+      password: 'fbpass',
+    });
+  });
+
+  test('normal Viewport-mode launch (no fallback fired) → render-session override stays unset', async () => {
+    seedProfiles([{ id: 'fb', name: 'Fallback', url: 'https://fallback.local' }]);
+    seedViewport({ fallbackProfileId: 'fb' });
+    const { createMainWindow } = requireFreshWindow();
+    await createMainWindow();
+    adoptionInstances[0].emit('online', true); // healthy connection, no fallback
+    assert.equal(renderSession.getRenderCredentialOverride(), null);
+  });
+
+  test('a stale override from a previous window is cleared at the start of a fresh normal launch', async () => {
+    renderSession.setRenderCredentialOverride({ url: 'https://stale.local' });
+    seedProfiles([{ id: 'a', name: 'A', url: 'https://a.local' }]);
+    seedViewport({ fallbackProfileId: null });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    assert.equal(win._url, 'https://nvr.local', 'must load the DEDICATED viewport URL, unaffected');
+    assert.equal(
+      renderSession.getRenderCredentialOverride(),
+      null,
+      'stale override must be cleared',
+    );
+  });
+
+  test('non-fatal errors never trigger the fallback', async () => {
+    seedProfiles([{ id: 'fb', name: 'Fallback', url: 'https://fallback.local' }]);
+    seedViewport({ fallbackProfileId: 'fb' });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    adoptionInstances[0].emit('error', { message: 'blip' });
+    adoptionInstances[0].emit('error', { message: 'blip', fatal: false });
+    assert.equal(win._url, 'https://nvr.local');
+  });
+
+  // ── grace window ───────────────────────────────────────────────────────────
+
+  test('no online within the 60s grace window + fallback set → falls back', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    seedProfiles([{ id: 'fb', name: 'Fallback', url: 'https://fallback.local' }]);
+    seedViewport({ fallbackProfileId: 'fb' });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    t.mock.timers.tick(60_000);
+    assert.equal(win._url, 'https://fallback.local');
+    assert.equal(adoptionInstances[0].stopCalls, 1);
+  });
+
+  test('online BEFORE the grace window expires → no fallback', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    seedProfiles([{ id: 'fb', name: 'Fallback', url: 'https://fallback.local' }]);
+    seedViewport({ fallbackProfileId: 'fb' });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    adoptionInstances[0].emit('online', true);
+    t.mock.timers.tick(120_000);
+    assert.equal(win._url, 'https://nvr.local', 'must stay on the viewport connection');
+    assert.equal(adoptionInstances[0].stopCalls, 0);
+  });
+
+  test('no fallback configured → NO grace timer is armed (client keeps retrying forever)', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    seedViewport({ fallbackProfileId: null });
+    const { createMainWindow } = requireFreshWindow();
+    const win = await createMainWindow();
+    t.mock.timers.tick(600_000);
+    assert.equal(win._url, 'https://nvr.local');
+    assert.equal(adoptionInstances[0].stopCalls, 0);
+  });
+});

--- a/test/main/window.test.js
+++ b/test/main/window.test.js
@@ -51,6 +51,7 @@ const storeApi = {
   saveWindowBounds: (b) => mockStoreInstance.set('bounds', b),
   isInitialised: () => mockStoreInstance.has('init'),
   markInitialised: () => mockStoreInstance.set('init', true),
+  getViewportConfig: () => mockStoreInstance.get('viewportConfig', { enabled: false, name: '' }),
 };
 
 const trayMock = {


### PR DESCRIPTION
**TL;DR** — each client window can act as its own Viewport and have its Live Views (multiviews) assigned centrally from within UniFi Protect, instead of a fixed liveview URL being pulled and configured in the client itself. It turns clients from *pull* viewers into *push* viewers — Protect decides what each display shows.

---

Hey! 👋 This adds an optional **Viewport mode** that makes a viewer window show up in Protect as a real **Viewport device** — the same kind of thing a hardware UniFi Protect Viewport is. Once it's adopted it appears under **Protect → Devices**, and you can **Share a Live View** to it. The window then displays that view fullscreen and follows along whenever you re-share — all managed centrally from Protect.

It's completely opt-in and off by default. If you never turn it on, nothing about the current profile/liveview behavior changes.

**Why I built it:** I run this app on a couple of wall displays and spare monitors, and hardcoding a liveview URL on each machine got old fast. With this I can drive all of them from Protect itself — assign and re-assign Live Views without walking over to each PC.

**How it works, roughly:** the window generates its own device identity (a self-signed cert + MAC kept under `userData`) and adopts over Protect's device channel — the same mTLS WebSocket the real hardware uses on port 7442. The first adoption uses a one-time token minted from the admin API; after that it reconnects keyless with a pinned certificate (trust-on-first-use, keyed by `host:port`). I was careful not to disable TLS verification anywhere — pinning stays strict, and the only lenient moment is the one-time probe that records the fingerprint. Once it's online, the Live View that Protect assigns just drives the existing `…/protect/dashboard/<id>` render path, so it reuses all the chrome-stripping this app already does. If it can't adopt for some reason, it falls back to a poller or a normal profile so the window still shows something.

There's a little UI for it too: a dedicated **Viewport** tab (console URL + an admin login, a device name, an optional fallback profile), a loading overlay that actually tells you what's going on ("Registering…", "assign a Live View to it in Protect…", "reconnecting…"), and a **Remove this Viewport from Protect** button that cleans up the device and the local identity when you're done. Credentials go through Electron's `safeStorage`, and there's a single-instance lock so you can't accidentally adopt twice.

One quirk worth knowing: Protect names adopted viewers by their model ("UP Viewport"), so the app renames the device to whatever you set, through the admin API — which meant sorting out UniFi OS's CSRF token on write requests.

**Requirements:** a UniFi OS console (UDM / UDM-Pro / UDM-SE / CloudKey Gen2+) on Protect **4.x–7.x+**.

**What's in the diff:** a new `src/main/viewport/` area (adoption, cert pinning, the wire protocol, admin-API calls, the render bridge) wired into `window.js` / `ipc.js` / `store.js` / `preload.js` / `config.html`, two runtime deps (`selfsigned` and `ws`), and a pretty thorough set of unit tests.

**On testing:** there are unit tests for the protocol codec, the cert-pin logic, the adoption/reconnect state machine, the admin-API path, and the mode gating — the suite passes on Node 22. I've also run it end-to-end on my own setup: a **UDM-SE**, fully up to date (**Protect 7.1.87**, **UniFi OS 5.1.26**), over a local single-VLAN network. That whole path works cleanly — adopt → online → Protect assigns a Live View → it renders → re-sharing to a different view follows along, and rename + the in-app remove both check out. That's the only environment it's been exercised in, though, so other console models, Protect versions, or more involved network setups may well need additional testing.

A few honest notes:
- The viewer side of the protocol isn't documented, so I reverse-engineered it from a live console (with a nod to `keshavdv/unifi-cam-proxy` for the handshake). It leans on undocumented endpoints and could need tweaks as Protect evolves — I tried to keep all that endpoint knowledge in one or two files so future fixes stay easy.
- Aided by AI assistance.
- It's a chunky PR. I'm very happy to split it up (say, the render/config plumbing first and the adoption piece second) or rework the approach if that's easier to review or fits the project better — just let me know what works for you.

Thanks for taking a look! 🙏
